### PR TITLE
allowing iam role attach of ssm ec2 managed policy

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -22,7 +22,6 @@ Statement:
         iam:PolicyArn:
           - arn:aws:iam::aws:policy/IAMReadOnlyAccess
           - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
-
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -19,7 +19,10 @@ Statement:
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
     Condition:
       ArnLike:
-        iam:PolicyArn: arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        iam:PolicyArn:
+          - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+          - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:


### PR DESCRIPTION

per review on changes on 
https://github.com/ansible/ansible/pull/49652

The permissions here are the minimals ones for the instance thats being managed to communicate with the ssm service which will in turn be managing the instance. Their effectively locked down, since the instance is being managed by the service, not that the instance is managing the service. From a cleanup perspective with the CI terminator, the only associated resource that remains visible within the console describes is the instance within the ssm service as a managed instance which is automatically garbage collected as soon as the service detects the instance is deleted.

