### PR TITLE
Add argcomplete to test requirements.

### DIFF
--- a/aws/test-requirements.txt
+++ b/aws/test-requirements.txt
@@ -1,3 +1,4 @@
+argcomplete
 pycodestyle
 pylint
 yamllint


### PR DESCRIPTION
It's needed for tab completion when using the cli tools, but we don't have a dedicated requirements file just for the cli currently.

However, it can also be used by pylint during static analysis, since it's imported by our code, so adding it to the test requirements instead.