### PR TITLE
Added ec2:CreateNetworkInterface permission

### DIFF
--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -36,6 +36,7 @@ Statement:
       - ec2:DeleteNatGateway
       - ec2:DescribeNatGateways
       - ec2:DescribeNetworkAcls
+      - ec2:CreateNetworkInterface
       - ec2:DeleteNetworkInterface
       - ec2:DescribeNetworkInterfaces
       - ec2:DetachNetworkInterface


### PR DESCRIPTION
The `ec2_instance` integration tests create multiple ENIs to attach to the instance