### PR TITLE
Update boto3/botocore and downgrade urllib3.

### DIFF
--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,9 +1,9 @@
-boto3==1.9.125
-botocore==1.12.125
+boto3==1.9.152
+botocore==1.12.152
 docutils==0.14
 jmespath==0.9.4
 python-dateutil==2.8.0
 requests==2.22.0
 s3transfer==0.2.0
 six==1.12.0
-urllib3==1.25.2
+urllib3==1.24.3


### PR DESCRIPTION
This maintains compatibility with boto3/botocore while keeping a version of urllib3 which has the latest security updates.