### PR TITLE
Added ec2:startInstances

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -55,6 +55,7 @@ Statement:
     Effect: Allow
     Action:
       - ec2:RunInstances
+      - ec2:StartInstances
     Resource:
       - arn:aws:ec2:us-east-1:{{ aws_account_id }}:instance/*
     Condition:


### PR DESCRIPTION
This is required by the `ec2_instance` tests:
https://app.shippable.com/github/ansible/ansible/runs/124621/102/tests