### PR TITLE
Use a non-temporary dir for the packaging dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
+/.cache
 *.retry
 *.pyc

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -4,7 +4,7 @@
     aws_region: "us-east-1"
     stage: "prod"
     terminator_policy: "{{ lookup('template', 'terminator-policy.json') }}"
-    packaging_dir: "/tmp/packaging"
+    packaging_dir: "{{ playbook_dir }}/../.cache/packaging"
   tasks:
     - name: load config
       tags: always


### PR DESCRIPTION
Using a temporary directory for the packaging cache can result in corrupted packages being uploaded when temporary files are cleaned up automatically on platforms like macOS.