### PR TITLE
Rename role assumption policy 

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -112,3 +112,4 @@ Statement:
     Resource:
       - arn:aws:iam::{{ aws_account_id }}:role/ansible_lambda_role
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
+      - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -1,6 +1,6 @@
 Version: '2012-10-17'
 Statement:
-  - Sid: AllowStsAssumeRoleTests
+  - Sid: AllowAssumeRoleTests
     Effect: Allow
     Action:
       - iam:CreateRole
@@ -15,13 +15,15 @@ Statement:
     Resource:
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-sts-*
-  - Sid: AllowStsAssumeRoleTestsAttachAndDetachRole
+      - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*
+  - Sid: AllowAssumeRoleTestsAttachAndDetachRole
     Effect: Allow
     Action:
       - iam:AttachRolePolicy
       - iam:DetachRolePolicy
     Resource:
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
+      - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*
     Condition:
       ArnLike:
         iam:PolicyArn:

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -14,7 +14,8 @@ Statement:
       - iam:RemoveRoleFromInstanceProfile
     Resource:
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
-      - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-sts-*
+       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-sts-*
+       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-*
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*
   - Sid: AllowAssumeRoleTestsAttachAndDetachRole
     Effect: Allow

--- a/aws/terminator/security_services.py
+++ b/aws/terminator/security_services.py
@@ -57,7 +57,7 @@ class IamInstanceProfile(Terminator):
 
     @property
     def ignore(self):
-        return not self.name.startswith('ansible-test-sts-')
+        return not self.name.startswith('ansible-test-')
 
     @property
     def created_time(self):


### PR DESCRIPTION
Rename role assumption policy as it's being used for non-sts tests now
Add role/ansible-test-* resources to also reflect this

@tremble makes a good point in https://github.com/ansible/ansible/pull/61256 that we've started overloading use of arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-* for tests that are not related to STS.