### PR TITLE
Fix indentation

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -14,8 +14,8 @@ Statement:
       - iam:RemoveRoleFromInstanceProfile
     Resource:
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
-       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-sts-*
-       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-*
+      - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-sts-*
+      - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-*
       - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*
   - Sid: AllowAssumeRoleTestsAttachAndDetachRole
     Effect: Allow


### PR DESCRIPTION
```
    Resource:
      - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-sts-*
       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-sts-*
       - arn:aws:iam::{{ aws_account_id }}:instance-profile/ansible-test-*
      - arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*
```
is turning into a list like
```
"Resource\": [\"arn:aws:iam::966509639900:role/ansible-test-sts-* - arn:aws:iam::966509639900:instance-profile/ansible-test-sts-* - arn:aws:iam::966509639900:instance-profile/ansible-test-*\", \"arn:aws:iam::966509639900:role/ansible-test-*\"]}
```