### PR TITLE
Allow the association/disassociation of EIPs to/from ENIs

### DIFF
--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -17,6 +17,8 @@ Statement:
       - ec2:AllocateAddress
       - ec2:DescribeAddresses
       - ec2:ReleaseAddress
+      - ec2:AssociateAddress
+      - ec2:DisassociateAddress
       - ec2:CreateCustomerGateway
       - ec2:DeleteCustomerGateway
       - ec2:DescribeCustomerGateways


### PR DESCRIPTION
This allows us to more thoroughly test EIP manipulation.

See also: https://github.com/ansible/ansible/pull/62332