### PR TITLE
Add ecr:PutImageTagMutability

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -47,6 +47,7 @@ Statement:
       - ec2:DescribeTransitGateways
       - ecr:CreateRepository
       - ecr:DescribeRepositories
+      - ecr:PutImageTagMutability
       - elasticloadbalancing:DescribeLoadBalancerAttributes
       - elasticloadbalancing:DescribeLoadBalancers
       - lambda:ListFunctions


### PR DESCRIPTION
The policy is required by https://github.com/ansible/ansible/pull/62871
which allows to enable/disable tag immutability on registries.