### PR TITLE
Allow m1.large instance type

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -68,6 +68,7 @@ Statement:
           - t2.micro
           - t3.nano
           - t3.micro
+          - m1.large
   - Sid: AllowEc2RunInstances
     Effect: Allow
     Action:

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -68,7 +68,7 @@ Statement:
           - t2.micro
           - t3.nano
           - t3.micro
-          - m1.large
+          - m1.large  # lowest cost instance type with EBS optimization supported
   - Sid: AllowEc2RunInstances
     Effect: Allow
     Action:


### PR DESCRIPTION
This is needed to allow the tests in [ansible/ansible#61222](https://github.com/ansible/ansible/pull/61222) to run (I have the updated tests and the fixed sanity checks changes locally, waiting on this to be merged before pushing).

I know the instance is quite a big one, but unfortunately, as you can see from the list, the auto ebs_optimization only works for these instance types, and m1.large seems to be the cheapest one.

/cc @jillr 