### PR TITLE
Add pip constraints for consistent test results.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: yamllint
 
 .PHONY: test-requirements
 test-requirements:
-	"$(PYTHON3)" -m pip install -r test-requirements.txt --disable-pip-version-check
+	"$(PYTHON3)" -m pip install -c constraints.txt -r test-requirements.txt --disable-pip-version-check
 
 .PHONY: yamllint
 yamllint:

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -14,7 +14,7 @@ test: pycodestyle pylint
 
 .PHONY: test-requirements
 test-requirements:
-	"$(PYTHON3)" -m pip install -r requirements.txt -r test-requirements.txt --disable-pip-version-check
+	"$(PYTHON3)" -m pip install -c ../constraints.txt -r requirements.txt -r test-requirements.txt --disable-pip-version-check
 
 .PHONY: pycodestyle
 pycodestyle:

--- a/aws/Makefile
+++ b/aws/Makefile
@@ -37,7 +37,7 @@ test: yamllint pycodestyle pylint
 
 .PHONY: test-requirements
 test-requirements:
-	"$(PYTHON3)" -m pip install -r requirements.txt -r test-requirements.txt --disable-pip-version-check
+	"$(PYTHON3)" -m pip install -c ../constraints.txt -r requirements.txt -r test-requirements.txt --disable-pip-version-check
 
 .PHONY: yamllint
 yamllint:

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,8 @@
+# freeze pylint and its requirements for consistent test results
+astroid == 2.2.5
+isort == 4.3.15
+lazy-object-proxy == 1.3.1
+mccabe == 0.6.1
+pylint == 2.3.1
+typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
+wrapt == 1.11.1


### PR DESCRIPTION
This should avoid spontaneous CI failures due to new releases of pylint and its dependencies.