### PR TITLE
Add permissions and termination for cloudwatch alarms

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -137,6 +137,13 @@ Statement:
       - logs:CreateLogGroup
       - logs:DeleteLogGroup
     Resource: arn:aws:logs:us-east-1:{{ aws_account_id }}:log-group:ansible-test*
+  - Sid: ModifyCloudwatchAlarms
+    Effect: Allow
+    Action:
+      - cloudwatch:PutMetricAlarm
+      - cloudwatch:DeleteAlarms
+      - cloudwatch:DescribeAlarms
+    Resource: arn:aws:cloudwatch:us-east-1:{{ aws_account_id }}:alarm:ansible-test*
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
     Action:

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -142,8 +142,12 @@ Statement:
     Action:
       - cloudwatch:PutMetricAlarm
       - cloudwatch:DeleteAlarms
-      - cloudwatch:DescribeAlarms
     Resource: arn:aws:cloudwatch:us-east-1:{{ aws_account_id }}:alarm:ansible-test*
+  - Sid: DescribeCloudwatchAlarms
+    Effect: Allow
+    Action:
+      - cloudwatch:DescribeAlarms
+    Resource: arn:aws:cloudwatch:us-east-1:{{ aws_account_id }}:alarm:*
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
     Action:

--- a/aws/terminator/application_services.py
+++ b/aws/terminator/application_services.py
@@ -367,3 +367,16 @@ class StepFunctions(Terminator):
 
     def terminate(self):
         return self.client.delete_state_machine(stateMachineArn=self.name)
+
+
+class CloudWatchAlarm(DbTerminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(credentials, CloudWatchAlarm, 'cloudwatch', lambda client: client.describe_alarms()['MetricAlarms'])
+
+    @property
+    def name(self):
+        return self.instance['AlarmName']
+
+    def terminate(self):
+        self.client.delete_alarms(AlarmNames=[self.name])


### PR DESCRIPTION
Permissions needed for https://github.com/ansible/ansible/pull/62669

cloudwatch alarms don't directly track their creation date.  Using boto3's describe_alarm_history will return history that might contain the created history item.  Alarm history is limited, so the create item might not be available.