### PR TITLE
Tidy up some extra permissions that appear unused

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -48,12 +48,10 @@ Statement:
       - ecr:CreateRepository
       - ecr:DescribeRepositories
       - ecr:PutImageTagMutability
-      - elasticloadbalancing:DescribeListenerCertificates
       - elasticloadbalancing:DescribeListeners
       - elasticloadbalancing:DescribeLoadBalancerAttributes
       - elasticloadbalancing:DescribeLoadBalancers
       - elasticloadbalancing:DescribeRules
-      - elasticloadbalancing:DescribeSSLPolicies
       - elasticloadbalancing:DescribeTags
       - elasticloadbalancing:DescribeTargetGroupAttributes
       - elasticloadbalancing:DescribeTargetGroups
@@ -94,17 +92,13 @@ Statement:
     Action:
       - ec2:CreateVolume
       - rds:CreateDBCluster
-      - elasticloadbalancing:AddListenerCertificates
       - elasticloadbalancing:CreateLoadBalancer
-      - elasticloadbalancing:CreateRule
       - lambda:InvokeFunction
     Resource:
       - arn:aws:ec2:us-east-1:{{ aws_account_id }}:volume/*
       - arn:aws:rds:us-east-1:{{ aws_account_id }}:cluster:*
       - arn:aws:elasticloadbalancing:us-east-1:{{ aws_account_id }}:*
       - arn:aws:lambda:us-east-1:{{ aws_account_id }}:function:*
-      - arn:aws:elasticloadbalancing:us-east-1:{{ aws_account_id }}:listener-rule/*
-      - arn:aws:acm:us-east-1:{{ aws_account_id }}:certificate/*
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
@@ -128,21 +122,13 @@ Statement:
       - elasticloadbalancing:CreateListener
       - elasticloadbalancing:CreateLoadBalancerListeners
       - elasticloadbalancing:CreateTargetGroup
-      - elasticloadbalancing:DeleteListener
       - elasticloadbalancing:DeleteLoadBalancer
       - elasticloadbalancing:DeleteLoadBalancerListeners
-      - elasticloadbalancing:DeleteRule
-      - elasticloadbalancing:DeleteTags
       - elasticloadbalancing:DeleteTargetGroup
-      - elasticloadbalancing:DeregisterTargets
       - elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer
       - elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer
       - elasticloadbalancing:ModifyLoadBalancerAttributes
-      - elasticloadbalancing:ModifyTargetGroup
-      - elasticloadbalancing:ModifyTargetGroupAttributes
-      - elasticloadbalancing:ModifyRule
       - elasticloadbalancing:RegisterTargets
-      - elasticloadbalancing:RemoveListenerCertificates
       - lambda:AddPermission
       - lambda:CreateFunction
       - lambda:DeleteFunction
@@ -172,9 +158,7 @@ Statement:
       - arn:aws:elasticbeanstalk:us-east-1:{{ aws_account_id }}:application/*
       - arn:aws:lambda:us-east-1:{{ aws_account_id }}:function:*
       - arn:aws:eks:us-east-1:{{ aws_account_id }}:cluster/*
-      - arn:aws:elasticloadbalancing:us-east-1:{{ aws_account_id }}:listener-rule/*
       - arn:aws:elasticloadbalancing:us-east-1:{{ aws_account_id }}:targetgroup/*
-      - arn:aws:acm:us-east-1:{{ aws_account_id }}:certificate/*
   - Sid: AllowEksCreateCluster
     Effect: Allow
     Action:


### PR DESCRIPTION
These were all added in https://github.com/mattclay/aws-terminator/pull/47. Initially the PR was for eks tests, and then ended up adding in things for elb_target since there was a large overlap. That made it tricky to see which things were required by which tests or not, and these appear to be unused. So for the sake of clarity and keeping things minimal, removing the extras for now. These are the set of permissions used by the elb_target integration tests PR (ansible/ansible#61256) as of today, none of which I am removing:

['ec2:AssociateRouteTable', 'ec2:AttachInternetGateway', 'ec2:AuthorizeSecurityGroupIngress', 'ec2:CreateInternetGateway', 'ec2:CreateRoute', 'ec2:CreateRouteTable', 'ec2:CreateSecurityGroup', 'ec2:CreateSubnet', 'ec2:CreateTags', 'ec2:CreateVpc', 'ec2:DeleteInternetGateway', 'ec2:DeleteRouteTable', 'ec2:DeleteSecurityGroup', 'ec2:DeleteSubnet', 'ec2:DeleteVpc', 'ec2:DescribeImages', 'ec2:DescribeInternetGateways', 'ec2:DescribeRouteTables', 'ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets', 'ec2:DescribeTags', 'ec2:DescribeVpcAttribute', 'ec2:DescribeVpcClassicLink', 'ec2:DescribeVpcs', 'ec2:DetachInternetGateway', 'ec2:DisassociateRouteTable', 'ec2:ModifyVpcAttribute', 'elasticloadbalancing:AddTags', 'elasticloadbalancing:CreateListener', 'elasticloadbalancing:CreateLoadBalancer', 'elasticloadbalancing:CreateTargetGroup', 'elasticloadbalancing:DeleteLoadBalancer', 'elasticloadbalancing:DeleteTargetGroup', 'elasticloadbalancing:DescribeListeners', 'elasticloadbalancing:DescribeLoadBalancerAttributes', 'elasticloadbalancing:DescribeLoadBalancers', 'elasticloadbalancing:DescribeRules', 'elasticloadbalancing:DescribeTags', 'elasticloadbalancing:DescribeTargetGroupAttributes', 'elasticloadbalancing:DescribeTargetGroups', 'elasticloadbalancing:DescribeTargetHealth', 'elasticloadbalancing:RegisterTargets', 'iam:AddRoleToInstanceProfile', 'iam:AttachRolePolicy', 'iam:CreateInstanceProfile', 'iam:CreateRole', 'iam:DeleteRole', 'iam:DetachRolePolicy', 'iam:GetRole', 'iam:ListAttachedRolePolicies', 'iam:ListInstanceProfilesForRole', 'iam:RemoveRoleFromInstanceProfile', 'lambda:AddPermission', 'lambda:CreateFunction', 'lambda:DeleteFunction', 'lambda:GetFunction', 'lambda:GetPolicy', 'sts:GetCallerIdentity']
