### PR TITLE
Update policy for lightsail testing

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -33,6 +33,12 @@ Statement:
       - ec2:StopInstances
       - ec2:TerminateInstances
       - ec2:UnassignPrivateIpAddresses
+      - lightsail:DeleteInstance
+      - lightsail:GetInstance
+      - lightsail:GetInstances
+      - lightsail:RebootInstance
+      - lightsail:StartInstance
+      - lightsail:StopInstance
     Resource:
       - "*"
     Condition:
@@ -181,3 +187,9 @@ Statement:
       - eks:CreateCluster
     Resource:
       - arn:aws:eks:us-east-1:{{ aws_account_id }}:cluster/*
+  - Sid: AllowLightsailCreateInstances
+    Effect: Allow
+    Action:
+      - lightsail:CreateInstances
+    Resource:
+      - arn:aws:lightsail:us-east-1:{{ aws_account_id }}:*

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -33,12 +33,6 @@ Statement:
       - ec2:StopInstances
       - ec2:TerminateInstances
       - ec2:UnassignPrivateIpAddresses
-      - lightsail:DeleteInstance
-      - lightsail:GetInstance
-      - lightsail:GetInstances
-      - lightsail:RebootInstance
-      - lightsail:StartInstance
-      - lightsail:StopInstance
     Resource:
       - "*"
     Condition:
@@ -171,9 +165,15 @@ Statement:
       - eks:CreateCluster
     Resource:
       - arn:aws:eks:us-east-1:{{ aws_account_id }}:cluster/*
-  - Sid: AllowLightsailCreateInstances
+  - Sid: AllowLightsail
     Effect: Allow
     Action:
       - lightsail:CreateInstances
+      - lightsail:DeleteInstance
+      - lightsail:GetInstance
+      - lightsail:GetInstances
+      - lightsail:RebootInstance
+      - lightsail:StartInstance
+      - lightsail:StopInstance
     Resource:
       - arn:aws:lightsail:us-east-1:{{ aws_account_id }}:*

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -378,3 +378,22 @@ class Elbv2TargetGroups(DbTerminator):
 
     def terminate(self):
         self.client.delete_target_group(TargetGroupArn=self.id)
+
+
+class Lightsail(Terminator):
+    @staticmethod
+    def create(credentials):
+        def _paginate_lightsail_instances(client):
+            return client.get_paginator('get_instances').paginate().build_full_result()['instances']
+        return Terminator._create(credentials, Lightsail, 'lightsail', _paginate_lightsail_instances)
+
+    @property
+    def name(self):
+        return self.instance['name']
+
+    @property
+    def created_time(self):
+        return self.instance['createdAt']
+
+    def terminate(self):
+        self.client.delete_instance(instanceName=self.name)


### PR DESCRIPTION
A PR for lightsail integration tests needs an update to the CI account.
Link to PR - https://github.com/ansible/ansible/pull/63770/

This is my first time submitting a patch here. So any help is greatly appreciated.

The `lightsail:CreateInstances` is the only action that incurs fees. So I have added that as a separate statement in the policy. Also, instances can only be created in us-east-1. I think that is how the other statements are written, so I tried to follow suit.

I wanted to add a condition so that only certain bundles could be used, but I couldn't find a way to do that.