### PR TITLE
Add Permissions for Cloudformation

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -93,6 +93,7 @@ Statement:
       - dynamodb:DescribeTable
       - kinesis:ListStreams
       - kinesis:DescribeStream
+      - cloudformation:ListStacks
     Resource: "*"
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
@@ -194,4 +195,4 @@ Statement:
       - cloudformation:DescribeChangeSet
       - cloudformation:ListChangeSets
       - cloudformation:ListStackResources
-    Resource: arn:aws:cloudformation:*:*:stack/*/*
+    Resource: arn:aws:cloudformation:us-east-1:{{ aws_account_id }}:stack/ansible-test*

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -180,3 +180,18 @@ Statement:
       - states:UpdateStateMachine
     Resource:
       - arn:aws:states:us-east-1:{{ aws_account_id }}:*
+  - Sid: Cloudformation
+    Effect: Allow
+    Action:
+      - cloudformation:CreateChangeSet
+      - cloudformation:DescribeStacks
+      - cloudformation:GetStackPolicy
+      - cloudformation:DescribeStackEvents
+      - cloudformation:CreateStack
+      - cloudformation:GetTemplate
+      - cloudformation:DeleteStack
+      - cloudformation:UpdateStack
+      - cloudformation:DescribeChangeSet
+      - cloudformation:ListChangeSets
+      - cloudformation:ListStackResources
+    Resource: arn:aws:cloudformation:*:*:stack/*/*

--- a/aws/terminator/application_services.py
+++ b/aws/terminator/application_services.py
@@ -7,6 +7,26 @@ import botocore.exceptions
 from . import DbTerminator, Terminator
 
 
+class Cloudformation(Terminator):
+    @staticmethod
+    def create(credentials):
+        def paginate_stacks(client):
+            return client.get_paginator('list_stacks').paginate().build_full_result()['StackSummaries']
+
+        return Terminator._create(credentials, Cloudformation, 'cloudformation', paginate_stacks)
+
+    @property
+    def created_time(self):
+        return self.instance['CreationTime']
+
+    @property
+    def name(self):
+        return self.instance['StackName']
+
+    def terminate(self):
+        self.client.delete_stack(StackName=self.name)
+
+
 class CloudWatchLogGroup(Terminator):
     @staticmethod
     def create(credentials):


### PR DESCRIPTION
Add permissions needed to run integration test for ansible cloudformation modules
Add Cloudformation terminator class since this is the first Cloudformation permissions

Added permissions to run tests for the ansible module cloudformation_info that are part of pull request https://github.com/ansible/ansible/pull/63008
The tests in that PR need to create/delete a stack as part of the test(which simply creates an SNS topic), as well as various get/describe/list activities that are testing the cloudformation_info module.