### PR TITLE
Add actions for aws_step_functions_state_machine_execution

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -177,6 +177,8 @@ Statement:
     Effect: Allow
     Action:
       - states:CreateStateMachine
+      - states:StartExecution
+      - states:StopExecution
       - states:UpdateStateMachine
     Resource:
       - arn:aws:states:us-east-1:{{ aws_account_id }}:*


### PR DESCRIPTION
aws_step_functions_state_machine_execution module can be used to start or stop execution of a AWS Step Functions state machine.
ansible PR - https://github.com/ansible/ansible/pull/64431