### PR TITLE
Describe Cloudformation stacks instead of listing, so don't show deleted stacks

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -93,7 +93,7 @@ Statement:
       - dynamodb:DescribeTable
       - kinesis:ListStreams
       - kinesis:DescribeStream
-      - cloudformation:ListStacks
+      - cloudformation:DescribeStacks
     Resource: "*"
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow

--- a/aws/terminator/application_services.py
+++ b/aws/terminator/application_services.py
@@ -11,14 +11,7 @@ class Cloudformation(Terminator):
     @staticmethod
     def create(credentials):
         def paginate_stacks(client):
-            # Don't show DELETE_COMPLETE stacks
-            status_filter = ['CREATE_IN_PROGRESS', 'CREATE_FAILED', 'CREATE_COMPLETE', 'ROLLBACK_IN_PROGRESS',
-                             'ROLLBACK_FAILED', 'ROLLBACK_COMPLETE', 'DELETE_IN_PROGRESS', 'DELETE_FAILED',
-                             'UPDATE_IN_PROGRESS', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS', 'UPDATE_COMPLETE',
-                             'UPDATE_ROLLBACK_IN_PROGRESS', 'UPDATE_ROLLBACK_FAILED',
-                             'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS', 'UPDATE_ROLLBACK_COMPLETE',
-                             'REVIEW_IN_PROGRESS']
-            return client.get_paginator('list_stacks').paginate(StackStatusFilter=status_filter).build_full_result()['StackSummaries']
+            return client.get_paginator('describe_stacks').paginate().build_full_result()['Stacks']
 
         return Terminator._create(credentials, Cloudformation, 'cloudformation', paginate_stacks)
 

--- a/aws/terminator/application_services.py
+++ b/aws/terminator/application_services.py
@@ -11,7 +11,14 @@ class Cloudformation(Terminator):
     @staticmethod
     def create(credentials):
         def paginate_stacks(client):
-            return client.get_paginator('list_stacks').paginate().build_full_result()['StackSummaries']
+            # Don't show DELETE_COMPLETE stacks
+            status_filter = ['CREATE_IN_PROGRESS', 'CREATE_FAILED', 'CREATE_COMPLETE', 'ROLLBACK_IN_PROGRESS',
+                             'ROLLBACK_FAILED', 'ROLLBACK_COMPLETE', 'DELETE_IN_PROGRESS', 'DELETE_FAILED',
+                             'UPDATE_IN_PROGRESS', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS', 'UPDATE_COMPLETE',
+                             'UPDATE_ROLLBACK_IN_PROGRESS', 'UPDATE_ROLLBACK_FAILED',
+                             'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS', 'UPDATE_ROLLBACK_COMPLETE',
+                             'REVIEW_IN_PROGRESS']
+            return client.get_paginator('list_stacks').paginate(StackStatusFilter=status_filter).build_full_result()['StackSummaries']
 
         return Terminator._create(credentials, Cloudformation, 'cloudformation', paginate_stacks)
 


### PR DESCRIPTION
Fixes #73 

All stacks that have ever been created are returned by default with list. This is both noisy and causes problems when, let's say hypothetically, a single test stack was created at some point in testing that does not conform to stack name being ansible-test*. Which is not a permitted resource path.
DescribeStacks avoids this.