### PR TITLE
Add action to create keypair in lightsail

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -172,8 +172,10 @@ Statement:
       - lightsail:CreateInstances
       - lightsail:CreateKeyPair
       - lightsail:DeleteInstance
+      - lightsail:DeleteKeyPair
       - lightsail:GetInstance
       - lightsail:GetInstances
+      - lightsail:GetKeyPairs
       - lightsail:RebootInstance
       - lightsail:StartInstance
       - lightsail:StopInstance

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -170,6 +170,7 @@ Statement:
     Effect: Allow
     Action:
       - lightsail:CreateInstances
+      - lightsail:CreateKeyPair
       - lightsail:DeleteInstance
       - lightsail:GetInstance
       - lightsail:GetInstances

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -397,3 +397,22 @@ class Lightsail(Terminator):
 
     def terminate(self):
         self.client.delete_instance(instanceName=self.name)
+
+
+class LightsailKeyPair(Terminator):
+    @staticmethod
+    def create(credentials):
+        def _paginate_lightsail_key_pairs(client):
+            return client.get_paginator('get_key_pairs').paginate().build_full_result()['keyPairs']
+        return Terminator._create(credentials, LightsailKeyPair, 'lightsail', _paginate_lightsail_key_pairs)
+
+    @property
+    def name(self):
+        return self.instance['name']
+
+    @property
+    def created_time(self):
+        return self.instance['createdAt']
+
+    def terminate(self):
+        self.client.delete_key_pair(keyPairName=self.name)


### PR DESCRIPTION
Based on https://github.com/ansible/ansible/pull/63770#issuecomment-553078130, we want to manage the keypair used while creating a lightsail instance within the testsuite itself. This means having the ability to create a keypair in lightsail. This adds the action required for that to the relevant policy statement.

Ansible PR - https://github.com/ansible/ansible/pull/63770