### PR TITLE
Allow broader cloudformation resource names

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -206,4 +206,4 @@ Statement:
       - cloudformation:ListStackResources
       - cloudformation:UpdateStack
       - cloudformation:UpdateTerminationProtection
-    Resource: arn:aws:cloudformation:us-east-1:{{ aws_account_id }}:stack/ansible-test*
+    Resource: arn:aws:cloudformation:us-east-1:{{ aws_account_id }}:stack/*


### PR DESCRIPTION
Restricting cloudformation to */ansible-test was overzealous, needs to support shippable as a resource prefix