### PR TITLE
Switch ACM to DbTerminator

### DIFF
--- a/aws/terminator/security_services.py
+++ b/aws/terminator/security_services.py
@@ -322,6 +322,5 @@ class ACMCertificate(DbTerminator):
     def name(self):
         return self.instance['CertificateArn']
 
-
     def terminate(self):
         self.client.delete_certificate(CertificateArn=self.id)


### PR DESCRIPTION
When an invalid cert exists in ACM, describe_certificates (to obtain the
timestamp) fails. They can still be deleted by ARN however.
See: https://github.com/ansible/ansible/issues/67788