### PR TITLE
Permit CI to describe AWS regions

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -23,6 +23,7 @@ Statement:
       - ec2:DescribeInstances
       - ec2:DescribeInstanceStatus
       - ec2:DescribeKeyPairs
+      - ec2:DescribeRegions
       - ec2:DescribeSnapshots
       - ec2:DescribeTags
       - ec2:DescribeVolumes


### PR DESCRIPTION
Required by https://github.com/ansible-collections/community.aws/pull/139 - Adding CI tests for aws_region_info

https://app.shippable.com/github/ansible-collections/community.aws/runs/418/34/console