### PR TITLE
Add classes and policy for AutoScalingGroups - split Compute policy

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -93,12 +93,12 @@ Statement:
         ec2:Region:
           - '{{ aws_region }}'
 
-  #- Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees
-  #  Effect: Allow
-  #  Action:
-  #    -
-  #  Resource:
-  #    - "*"
+  # - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees
+  #   Effect: Allow
+  #   Action:
+  #     -
+  #   Resource:
+  #     - "*"
 
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
@@ -106,9 +106,6 @@ Statement:
       - ec2:DescribeAvailabilityZones
       - ec2:DescribeSpotPriceHistory
       - ec2:DescribeTransitGateways
-      - ecr:CreateRepository
-      - ecr:DescribeRepositories
-      - ecr:PutImageTagMutability
       - elasticloadbalancing:DescribeListeners
       - elasticloadbalancing:DescribeLoadBalancerAttributes
       - elasticloadbalancing:DescribeLoadBalancers
@@ -119,10 +116,6 @@ Statement:
       - elasticloadbalancing:DescribeTargetHealth
       - elasticloadbalancing:DeregisterTargets
       - elasticloadbalancing:ModifyTargetGroupAttributes
-      - lambda:ListFunctions
-      - lambda:ListVersionsByFunction
-      - lambda:ListAliases
-      - lambda:ListEventSourceMappings
     Resource:
       - "*"
 
@@ -130,17 +123,10 @@ Statement:
     Effect: Allow
     Action:
       - ec2:CreateVolume
-      - eks:CreateCluster
       - elasticloadbalancing:CreateLoadBalancer
-      - lambda:InvokeFunction
-      - lightsail:CreateInstances
-      - lightsail:StartInstance
     Resource:
       - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:volume/*'
-      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
-      - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
 
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
@@ -157,20 +143,6 @@ Statement:
       - autoscaling:DescribePolicies
       - autoscaling:PutScalingPolicy
       - ec2:DeleteVolume
-      - ecr:DeleteLifecyclePolicy
-      - ecr:DeleteRepository
-      - ecr:DeleteRepositoryPolicy
-      - ecr:GetLifecyclePolicy
-      - ecr:GetRepositoryPolicy
-      - ecr:PutLifecyclePolicy
-      - ecr:SetRepositoryPolicy
-      - eks:ListClusters
-      - eks:DescribeCluster
-      - eks:DeleteCluster
-      - elasticbeanstalk:CreateApplication
-      - elasticbeanstalk:DeleteApplication
-      - elasticbeanstalk:DescribeApplications
-      - elasticbeanstalk:UpdateApplication
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:ConfigureHealthCheck
       - elasticloadbalancing:CreateListener
@@ -192,31 +164,10 @@ Statement:
       - elasticfilesystem:CreateTags
       - elasticfilesystem:DeleteFileSystem
       - elasticfilesystem:DeleteMountTarget
-      - lambda:AddPermission
-      - lambda:CreateFunction
-      - lambda:DeleteFunction
-      - lambda:GetFunction
-      - lambda:GetFunctionConfiguration
-      - lambda:GetPolicy
-      - lambda:RemovePermission
-      - lambda:UpdateFunctionConfiguration
-      - lightsail:CreateKeyPair
-      - lightsail:DeleteInstance
-      - lightsail:DeleteKeyPair
-      - lightsail:GetInstance
-      - lightsail:GetInstances
-      - lightsail:GetKeyPairs
-      - lightsail:RebootInstance
-      - lightsail:StopInstance
     Resource:
       - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:launchConfiguration:*'
       - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*'
       - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:volume/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
-      - 'arn:aws:elasticbeanstalk:{{ aws_region }}:{{ aws_account_id }}:application/*'
       - 'arn:aws:elasticfilesystem:{{ aws_region }}:{{ aws_account_id }}:file-system/*'
-      - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
-      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:targetgroup/*'
-      - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -103,6 +103,9 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - autoscaling:DescribeAutoScalingGroups
+      - autoscaling:DescribeLaunchConfigurations
+      - autoscaling:DescribePolicies
       - ec2:DescribeAvailabilityZones
       - ec2:DescribeSpotPriceHistory
       - ec2:DescribeTransitGateways
@@ -138,9 +141,6 @@ Statement:
       - autoscaling:DeleteTags
       - autoscaling:DescribeTags
       - autoscaling:DescribeAdjustmentTypes
-      - autoscaling:DescribeAutoScalingGroups
-      - autoscaling:DescribeLaunchConfigurations
-      - autoscaling:DescribePolicies
       - autoscaling:PutScalingPolicy
       - ec2:DeleteVolume
       - elasticloadbalancing:AddTags

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -1,5 +1,54 @@
 Version: '2012-10-17'
 Statement:
+
+  # Restrict the types of instances that can be started
+  - Sid: AllowEc2RunInstancesInstanceType
+    Effect: Allow
+    Action:
+      - autoscaling:CreateLaunchConfiguration
+      - ec2:RunInstances
+      - ec2:StartInstances
+    Resource:
+      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:launchConfiguration:*'
+      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*'
+      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:instance/*'
+    Condition:
+      StringEqualsIfExists:
+        ec2:InstanceType:
+          - t2.nano
+          - t2.micro
+          - t3.nano
+          - t3.micro
+          - m1.large  # lowest cost instance type with EBS optimization supported
+
+  # Restrict the Types of instance that can be spun up using ASGs
+  - Sid: AllowAsgInstancesInstanceType
+    Effect: Allow
+    Action:
+      - autoscaling:CreateAutoScalingGroup
+      - autoscaling:UpdateAutoScalingGroup
+    Resource:
+      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*'
+    Condition:
+      StringEqualsIfExists:
+        autoscaling:InstanceTypes:
+          - t3.nano
+          - t3.micro
+
+  # Permit RunInstance to access any of the usual objects attached to an
+  # instance
+  - Sid: AllowEc2RunInstances
+    Effect: Allow
+    Action:
+      - ec2:RunInstances
+    Resource:
+      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:key-pair/*'
+      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:network-interface/*'
+      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:security-group/*'
+      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:subnet/*'
+      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:volume/*'
+      - 'arn:aws:ec2:{{ aws_region }}::image/*'
+
   - Sid: AllowRegionalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
@@ -43,6 +92,14 @@ Statement:
       StringEquals:
         ec2:Region:
           - '{{ aws_region }}'
+
+  #- Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees
+  #  Effect: Allow
+  #  Action:
+  #    -
+  #  Resource:
+  #    - "*"
+
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
@@ -66,46 +123,39 @@ Statement:
       - lambda:ListVersionsByFunction
       - lambda:ListAliases
       - lambda:ListEventSourceMappings
-    Resource: "*"
-  - Sid: AllowEc2RunInstancesInstanceType
-    Effect: Allow
-    Action:
-      - ec2:RunInstances
-      - ec2:StartInstances
     Resource:
-      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:instance/*'
-    Condition:
-      StringEquals:
-        ec2:InstanceType:
-          - t2.nano
-          - t2.micro
-          - t3.nano
-          - t3.micro
-          - m1.large  # lowest cost instance type with EBS optimization supported
-  - Sid: AllowEc2RunInstances
-    Effect: Allow
-    Action:
-      - ec2:RunInstances
-    Resource:
-      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:key-pair/*'
-      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:network-interface/*'
-      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:security-group/*'
-      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:subnet/*'
-      - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:volume/*'
-      - 'arn:aws:ec2:{{ aws_region }}::image/*'
+      - "*"
+
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
     Action:
       - ec2:CreateVolume
+      - eks:CreateCluster
       - elasticloadbalancing:CreateLoadBalancer
       - lambda:InvokeFunction
+      - lightsail:CreateInstances
+      - lightsail:StartInstance
     Resource:
       - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:volume/*'
+      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
+      - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
+
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - autoscaling:CreateOrUpdateTags
+      - autoscaling:DeleteAutoScalingGroup
+      - autoscaling:DeleteLaunchConfiguration
+      - autoscaling:DeletePolicy
+      - autoscaling:DeleteTags
+      - autoscaling:DescribeTags
+      - autoscaling:DescribeAdjustmentTypes
+      - autoscaling:DescribeAutoScalingGroups
+      - autoscaling:DescribeLaunchConfigurations
+      - autoscaling:DescribePolicies
+      - autoscaling:PutScalingPolicy
       - ec2:DeleteVolume
       - ecr:DeleteLifecyclePolicy
       - ecr:DeleteRepository
@@ -150,7 +200,17 @@ Statement:
       - lambda:GetPolicy
       - lambda:RemovePermission
       - lambda:UpdateFunctionConfiguration
+      - lightsail:CreateKeyPair
+      - lightsail:DeleteInstance
+      - lightsail:DeleteKeyPair
+      - lightsail:GetInstance
+      - lightsail:GetInstances
+      - lightsail:GetKeyPairs
+      - lightsail:RebootInstance
+      - lightsail:StopInstance
     Resource:
+      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:launchConfiguration:*'
+      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*'
       - 'arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:volume/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
@@ -159,24 +219,4 @@ Statement:
       - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:targetgroup/*'
-  - Sid: AllowEksCreateCluster
-    Effect: Allow
-    Action:
-      - eks:CreateCluster
-    Resource:
-      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
-  - Sid: AllowLightsail
-    Effect: Allow
-    Action:
-      - lightsail:CreateInstances
-      - lightsail:CreateKeyPair
-      - lightsail:DeleteInstance
-      - lightsail:DeleteKeyPair
-      - lightsail:GetInstance
-      - lightsail:GetInstances
-      - lightsail:GetKeyPairs
-      - lightsail:RebootInstance
-      - lightsail:StartInstance
-      - lightsail:StopInstance
-    Resource:
       - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'

--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -48,7 +48,7 @@ Statement:
       - ec2:DeleteRoute
       - ec2:AssociateRouteTable
       - ec2:DisassociateRouteTable
-      #- ec2:ReplaceRouteTableAssociation
+      # - ec2:ReplaceRouteTableAssociation
       - ec2:CreateRouteTable
       - ec2:DeleteRouteTable
       - ec2:DescribeRouteTables

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -1,0 +1,74 @@
+Version: '2012-10-17'
+Statement:
+
+  - Sid: AllowResourceRestrictedActionsWhichIncurFees
+    Effect: Allow
+    Action:
+      - eks:CreateCluster
+      - lambda:InvokeFunction
+      - lightsail:CreateInstances
+      - lightsail:StartInstance
+    Resource:
+      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
+      - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
+      - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
+
+  - Sid: AllowResourceRestrictedActionsWhichIncurNoFees
+    Effect: Allow
+    Action:
+      - ecr:DeleteLifecyclePolicy
+      - ecr:DeleteRepository
+      - ecr:DeleteRepositoryPolicy
+      - ecr:GetLifecyclePolicy
+      - ecr:GetRepositoryPolicy
+      - ecr:PutLifecyclePolicy
+      - ecr:SetRepositoryPolicy
+      - eks:ListClusters
+      - eks:DescribeCluster
+      - eks:DeleteCluster
+      - elasticbeanstalk:CreateApplication
+      - elasticbeanstalk:DeleteApplication
+      - elasticbeanstalk:DescribeApplications
+      - elasticbeanstalk:UpdateApplication
+      - lambda:AddPermission
+      - lambda:CreateFunction
+      - lambda:DeleteFunction
+      - lambda:GetFunction
+      - lambda:GetFunctionConfiguration
+      - lambda:GetPolicy
+      - lambda:RemovePermission
+      - lambda:UpdateFunctionConfiguration
+      - lightsail:CreateKeyPair
+      - lightsail:DeleteInstance
+      - lightsail:DeleteKeyPair
+      - lightsail:GetInstance
+      - lightsail:GetInstances
+      - lightsail:GetKeyPairs
+      - lightsail:RebootInstance
+      - lightsail:StopInstance
+    Resource:
+      - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
+      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
+      - 'arn:aws:elasticbeanstalk:{{ aws_region }}:{{ aws_account_id }}:application/*'
+      - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
+      - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
+
+  # - Sid: AllowUnrestrictedResourceActionsWhichIncurFees
+  #   Effect: Allow
+  #   Action:
+  #     -
+  #   Resource:
+  #     - "*"
+
+  - Sid: AllowUnrestrictedResourceActionsWhichIncurNoFees
+    Effect: Allow
+    Action:
+      - ecr:CreateRepository
+      - ecr:DescribeRepositories
+      - ecr:PutImageTagMutability
+      - lambda:ListFunctions
+      - lambda:ListVersionsByFunction
+      - lambda:ListAliases
+      - lambda:ListEventSourceMappings
+    Resource:
+      - "*"

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -407,3 +407,54 @@ class LightsailKeyPair(Terminator):
 
     def terminate(self):
         self.client.delete_key_pair(keyPairName=self.name)
+
+
+class AutoScalingGroup(Terminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(credentials, AutoScalingGroup, 'autoscaling', lambda client: client.describe_auto_scaling_groups()['AutoScalingGroups'])
+
+    @property
+    def id(self):
+        return self.instance['AutoScalingGroupName']
+
+    @property
+    def name(self):
+        return self.instance['AutoScalingGroupName']
+
+    @property
+    def created_time(self):
+        return self.instance['CreatedTime']
+
+    def terminate(self):
+        self.client.delete_auto_scaling_group(AutoScalingGroupName=self.name, ForceDelete=True)
+
+
+class LaunchConfiguration(Terminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(
+            credentials,
+            LaunchConfiguration,
+            'autoscaling',
+            lambda client: client.describe_launch_configurations()['LaunchConfigurations']
+        )
+
+    @property
+    def id(self):
+        return self.instance['LaunchConfigurationName']
+
+    @property
+    def name(self):
+        return self.instance['LaunchConfigurationName']
+
+    @property
+    def created_time(self):
+        return self.instance['CreatedTime']
+
+    def terminate(self):
+        try:
+            self.client.delete_launch_configuration(LaunchConfigurationName=self.name)
+        except botocore.exceptions.ClientError as ex:
+            if not ex.response['Error']['Code'] == 'ResourceInUseFault':
+                raise


### PR DESCRIPTION
Integration tests for https://github.com/ansible-collections/community.aws/pull/197 need some additional permissions.  ASG feels like it belongs in the compute policy which is now too large so split off some of the more PaaS-y services into a separate policy.

@jillr I think we also need to teach terminator how to delete ASGs, but I'm not quite sure where to start.