### PR TITLE
Extend storage services permissions for s3 bucket metrics configuration 

### DIFF
--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -32,4 +32,6 @@ Statement:
       - s3:PutBucketNotification
       - s3:GetBucketLogging
       - s3:PutBucketLogging
+      - s3:GetMetricsConfiguration
+      - s3:PutMetricsConfiguration
     Resource: "*"

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -33,5 +33,10 @@ Statement:
       - s3:GetBucketLogging
       - s3:PutBucketLogging
       - s3:GetMetricsConfiguration
+    Resource: "*"
+
+  - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees
+    Effect: Allow
+    Action:
       - s3:PutMetricsConfiguration
     Resource: "*"


### PR DESCRIPTION
Required for new s3_metrics_configuration module
* `s3:GetMetricsConfiguration` covers get and list s3 bucket metrics configuration operations
* `s3:PutMetricsConfiguration` covers put and delete s3 bucket metrics configuration operations

See https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html