### PR TITLE
Permit Amazon Autoscaling to automatically create it's default ServiceLinkedRoles

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -148,3 +148,16 @@ Statement:
       - acm:DeleteCertificate
     Resource:
       - 'arn:aws:acm:{{ aws_region }}:{{ aws_account_id }}:certificate/*'
+
+  # This allows AWS Services to autmatically create their Default Service Linked Roles
+  # These have fixed policies and can only be assumed by the service itself.
+  - Sid: AllowServiceLinkedRoleCreation
+    Effect: Allow
+    Action:
+      - iam:CreateServiceLinkedRole
+    Resource:
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/autoscaling.amazonaws.com/*'
+    Condition:
+      ForAnyValue:StringEquals:
+        iam:AWSServiceName:
+          - 'autoscaling.amazonaws.com'


### PR DESCRIPTION
When you first try to use an AWS service that makes use of ServiceLinkedRoles it will automatically try to create a Role behind the scenes for you (using your permissions).  This role has very limited access and neither the permissions nor the assume_policy can be changed.

https://aws.amazon.com/blogs/security/introducing-an-easier-way-to-delegate-permissions-to-aws-services-service-linked-roles/