### PR TITLE
Update storage-services.yaml

### DIFF
--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -33,6 +33,8 @@ Statement:
       - s3:GetBucketLogging
       - s3:PutBucketLogging
       - s3:GetMetricsConfiguration
+      - s3:GetBucketPublicAccessBlock
+      - s3:PutBucketPublicAccessBlock
     Resource: "*"
 
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees


### PR DESCRIPTION
Addind Get/PubPublicAccessBlock
Fix failing integration test
<https://github.com/ansible-collections/amazon.aws/pull/171>

```
  File "/usr/local/lib/python3.7/dist-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/dist-packages/botocore/client.py", line 676, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the GetPublicAccessBlock operation: Access Denied
```