### PR TITLE
Increase age_limits on resources

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -82,7 +82,7 @@ To start using `cleanup.py` you will need to:
       cleanup     : DEBUG    ignored Ec2Instance: name=, id=i-0c18f88091e78898e age=0 days, 0:05:32, stale=False
       cleanup     : DEBUG    checked Ec2Instance: name=, id=i-0630e2ba640d7dbf1 age=1 days, 20:49:03, stale=True
 
-* The class property `age_limit` determines when a resource becomes stale. This is 10 minutes by default. Once a resource is stale, the terminator can delete it. Use check mode (-c or --check) to see what your class would delete without actually removing it.
+* The class property `age_limit` determines when a resource becomes stale. This is 20 minutes by default. Once a resource is stale, the terminator can delete it. Use check mode (-c or --check) to see what your class would delete without actually removing it.
 * Once a resource is stale you can test that it can be cleaned up by removing the check mode flag.
   For example, `python cleanup.py --stage dev --target Ec2Instance -v`.
 * You can forcibly delete resources that are not stale by using --force (or -f). Be aware that this can also remove resources that do not use the Terminator or DbTerminator base classes. Such unsupported resources will not be cleaned up by the CI account.

--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -193,7 +193,7 @@ class Terminator(abc.ABC):
 
     @property
     def age_limit(self) -> datetime.timedelta:
-        return datetime.timedelta(minutes=10)
+        return datetime.timedelta(minutes=20)
 
     @property
     def id(self) -> typing.Optional[str]:

--- a/aws/terminator/networking.py
+++ b/aws/terminator/networking.py
@@ -59,7 +59,7 @@ class Ec2CustomerGateway(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=15)
+        return datetime.timedelta(minutes=25)
 
     @property
     def id(self):
@@ -101,7 +101,7 @@ class Ec2Subnet(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=15)
+        return datetime.timedelta(minutes=25)
 
     @property
     def id(self):
@@ -130,7 +130,7 @@ class Ec2InternetGateway(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=15)
+        return datetime.timedelta(minutes=25)
 
     @property
     def id(self):
@@ -220,7 +220,7 @@ class Ec2Eni(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=15)
+        return datetime.timedelta(minutes=25)
 
     @property
     def id(self):
@@ -354,7 +354,7 @@ class Ec2SecurityGroup(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=15)
+        return datetime.timedelta(minutes=30)
 
     @property
     def id(self):

--- a/aws/terminator/security_services.py
+++ b/aws/terminator/security_services.py
@@ -73,7 +73,7 @@ class IamInstanceProfile(Terminator):
 class Waf(DbTerminator):
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=20)
+        return datetime.timedelta(minutes=30)
 
     @property
     def change_token(self):
@@ -96,7 +96,7 @@ class WafWebAcl(Waf):
     @property
     def age_limit(self):
         # Try to delete WafWebAcl first, because WafRule objects cannot be deleted if used in any WebACL
-        return datetime.timedelta(minutes=10)
+        return datetime.timedelta(minutes=20)
 
     @property
     def id(self):


### PR DESCRIPTION
We have a number of test suites which keep hitting these time limits.

While we should aim for keeping the tests relatively 'fast', and potentially breaking things out in parallel, 10 minutes starts causing problems where we need to test that Instances boot and do something (for example the ssm connection test where Windows needs to boot and install the plugins, this seems to take right around 8-9 minutes).