### PR TITLE
allow ec2:ModifyVolume

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -81,6 +81,7 @@ Statement:
       - ec2:ImportKeyPair
       - ec2:ModifyImageAttribute
       - ec2:ModifyInstanceAttribute
+      - ec2:ModifyVolume
       - ec2:RegisterImage
       - ec2:ReplaceIamInstanceProfileAssociation
       - ec2:StopInstances


### PR DESCRIPTION
Required by https://github.com/ansible-collections/amazon.aws/pull/215

CI is currently failing because modifying an existing ebs volume is not allowed

> ModifyVolume operation: You are not authorized to perform this operation.