### PR TITLE
Allow to describe instance health on ELBs

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -127,6 +127,7 @@ Statement:
       - elasticloadbalancing:DescribeTags
       - elasticloadbalancing:DescribeTargetGroupAttributes
       - elasticloadbalancing:DescribeTargetGroups
+      - elasticloadbalancing:DescribeInstanceHealth
       - elasticloadbalancing:DescribeTargetHealth
       - elasticloadbalancing:DeregisterTargets
       - elasticloadbalancing:ModifyListener


### PR DESCRIPTION
This permission is needed to use the classic elb_classic_info module on elb_classic integration tests (https://github.com/ansible-collections/community.aws/pull/215).