### PR TITLE
Correct release call for Lightsail IPs

### DIFF
--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -429,7 +429,7 @@ class LightsailStaticIp(Terminator):
         return self.instance['createdAt']
 
     def terminate(self):
-        self.client.delete_instance(instanceName=self.name)
+        self.client.release_static_ip(staticIpName=self.name)
 
 
 class AutoScalingGroup(Terminator):


### PR DESCRIPTION
I missed that this needs to be release_static_ip, not delete_instance. Tested locally already.