### PR TITLE
Delete inline policies from roles before deletion

### DIFF
--- a/aws/terminator/security_services.py
+++ b/aws/terminator/security_services.py
@@ -38,6 +38,8 @@ class IamRole(Terminator):
 
         for policy in self.client.list_attached_role_policies(RoleName=self.name)['AttachedPolicies']:
             self.client.detach_role_policy(RoleName=self.name, PolicyArn=policy['PolicyArn'])
+        for policy in self.client.list_role_policies(RoleName=self.name)['PolicyNames']:
+            self.client.delete_role_policy(RoleName=self.name, PolicyName=policy)
 
         self.client.delete_role(RoleName=self.name)
 


### PR DESCRIPTION
The delete api call will fail unless all policies (managed and inline) are removed.

While we don't currently allow attaching inline policies in CI, aws-terminator is helpful for cleaning up personal accounts too.