### PR TITLE
Ignore S3 'NoSuchBucket' errors

### DIFF
--- a/aws/terminator/application_services.py
+++ b/aws/terminator/application_services.py
@@ -214,7 +214,9 @@ class S3Bucket(Terminator):
 
         try:
             self.client.delete_bucket(Bucket=self.name)
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError as ex:
+            if ex.response['Error']['Code'] == 'NoSuchBucket':
+                return
             for keys in _paginated_list(self.name):
                 self.client.delete_objects(
                     Bucket=self.name,


### PR DESCRIPTION
Occasionally buckets will still be listed, but attempting to access/delete them will throw an exception.  They are 'deleted' but still show up in listings for a while.