### PR TITLE
Add AWS Glue Job permissions

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -103,6 +103,12 @@ Statement:
       - kinesis:RemoveTagsFromStream
       - kinesis:StartStreamEncryption
       - kinesis:StopStreamEncryption
+      - glue:DeleteJob
+      - glue:GetJob
+      - glue:GetTags
+      - glue:TagResource
+      - glue:UntagResource
+      - glue:UpdateJob
     Resource:
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:parameter/*'
       - 'arn:aws:codebuild:{{ aws_region }}:{{ aws_account_id }}:*'
@@ -113,6 +119,7 @@ Statement:
       - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
+      - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:job/*'
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
     Action:
@@ -125,9 +132,11 @@ Statement:
       - kinesis:DeleteStream
       - kinesis:IncreaseStreamRetentionPeriod
       - kinesis:UpdateShardCount
+      - glue:CreateJob
     Resource:
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
+      - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:job/*'
   - Sid: ModifyCloudwatchLogs
     Effect: Allow
     Action:

--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -72,6 +72,27 @@ class GlueConnection(Terminator):
         self.client.delete_connection(ConnectionName=self.name)
 
 
+class GlueJob(Terminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(credentials, GlueJob, 'glue', lambda client: client.get_jobs()['Jobs'])
+
+    @property
+    def id(self):
+        return self.instance['Name']
+
+    @property
+    def name(self):
+        return self.instance['Name']
+
+    @property
+    def created_time(self):
+        return self.instance['CreatedOn']
+
+    def terminate(self):
+        self.client.delete_job(JobName=self.name)
+
+
 class Glacier(Terminator):
     @staticmethod
     def create(credentials):


### PR DESCRIPTION
This allows AWS Glue integration tests to be executed, per @tremble
recommendation in https://github.com/ansible-collections/community.aws/pull/480

This replaces https://github.com/mattclay/aws-terminator/pull/95 which appears to have been abandoned.