### PR TITLE
Add AWS Glue Crawler permissions

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -66,6 +66,9 @@ Statement:
       - kinesis:DescribeStream
       - cloudformation:DescribeStacks
       - cloudformation:ListExports
+      - glue:GetConnections
+      - glue:GetCrawlers
+      - glue:GetJobs
     Resource: "*"
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -107,12 +107,15 @@ Statement:
       - kinesis:RemoveTagsFromStream
       - kinesis:StartStreamEncryption
       - kinesis:StopStreamEncryption
+      - glue:DeleteCrawler
       - glue:DeleteJob
+      - glue:GetCrawler
       - glue:GetJob
       - glue:GetTags
       - glue:TagResource
       - glue:UntagResource
       - glue:UpdateJob
+      - glue:UpdateCrawler
     Resource:
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:parameter/*'
       - 'arn:aws:codebuild:{{ aws_region }}:{{ aws_account_id }}:*'
@@ -123,6 +126,7 @@ Statement:
       - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
+      - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:crawler/*'
       - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:job/*'
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
@@ -137,11 +141,13 @@ Statement:
       - kinesis:DeleteStream
       - kinesis:IncreaseStreamRetentionPeriod
       - kinesis:UpdateShardCount
+      - glue:CreateCrawler
       - glue:CreateJob
     Resource:
       - 'arn:aws:sns:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
+      - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:crawler/*'
       - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:job/*'
   - Sid: ModifyCloudwatchLogs
     Effect: Allow

--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -72,6 +72,27 @@ class GlueConnection(Terminator):
         self.client.delete_connection(ConnectionName=self.name)
 
 
+class GlueCrawler(Terminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(credentials, GlueCrawler, 'glue', lambda client: client.get_crawlers()['Crawlers'])
+
+    @property
+    def id(self):
+        return self.instance['Name']
+
+    @property
+    def name(self):
+        return self.instance['Name']
+
+    @property
+    def created_time(self):
+        return self.instance['CreationTime']
+
+    def terminate(self):
+        self.client.delete_crawler(Name=self.name)
+
+
 class GlueJob(Terminator):
     @staticmethod
     def create(credentials):


### PR DESCRIPTION
This allows AWS Glue crawler integration tests to be executed:
https://github.com/ansible-collections/community.aws/pull/546