### PR TITLE
Ignore VPC Connections in deleted or deleting

### DIFF
--- a/aws/terminator/networking.py
+++ b/aws/terminator/networking.py
@@ -320,6 +320,12 @@ class Ec2VpnConnection(DbTerminator):
     def name(self):
         return get_tag_dict_from_tag_list(self.instance.get('Tags')).get('Name')
 
+    @property
+    def ignore(self):
+        # describe_vpn_connections will return results in deleting and deleted states.
+        # Ignore connections in these current states.
+        return self.instance.get('State') in ['deleting', 'deleted']
+
     def terminate(self):
         self.client.delete_vpn_connection(VpnConnectionId=self.id)
 


### PR DESCRIPTION
We occasionally see errors like `An error occurred (InvalidVpnConnectionID.NotFound) when calling the DeleteVpnConnection operation: The vpnConnection ID 'vpn-04447b28bfff63a30' does not exist`. Ignore connections in deleted/delting.