### PR TITLE
Re-add global policy for DescribeAZs, was lost in 150

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -105,6 +105,7 @@ Statement:
       - autoscaling:DescribeInstanceRefreshes
       - autoscaling:DescribeLaunchConfigurations
       - autoscaling:DescribePolicies
+      - ec2:DescribeAvailabilityZones
       - elasticloadbalancing:DeleteRule
       - elasticloadbalancing:DescribeListeners
       - elasticloadbalancing:DeleteListener


### PR DESCRIPTION
aws_az_info tests are failing