### PR TITLE
Added describe event rule permission

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -51,6 +51,11 @@ Statement:
       - ec2messages:GetEndpoint
       - ec2messages:GetMessages
       - ec2messages:SendReply
+      - events:CreateRule
+      - events:DescribeRule
+      - events:DeleteRule
+      - events:ListTargetsByRule
+      - events:PutRule
       - codebuild:BatchGetProjects
       - codebuild:ListProjects
       - codecommit:ListRepositories
@@ -163,14 +168,6 @@ Statement:
       - logs:PutMetricFilter
     Resource:
       - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:ansible-test*'
-  - Sid: DescribeEventRules
-    Effect: Allow
-    Action:
-      - events:DescribeRule
-      - events:CreateRule
-      - events:DeleteRule
-    Resource:
-      - 'arn:aws:events:{{ aws_region }}:{{ aws_account_id }}:rule:cloudwatch_event_rule*'
   - Sid: ModifyCloudwatchAlarms
     Effect: Allow
     Action:

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -163,6 +163,12 @@ Statement:
       - logs:PutMetricFilter
     Resource:
       - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:ansible-test*'
+  - Sid: DescribeEventRules
+    Effect: Allow
+    Action:
+      - events:DescribeRule
+    Resource:
+      - 'arn:aws:events:{{ aws_region }}:{{ aws_account_id }}:rule:cloudwatch_event_rule*'
   - Sid: ModifyCloudwatchAlarms
     Effect: Allow
     Action:

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -167,6 +167,8 @@ Statement:
     Effect: Allow
     Action:
       - events:DescribeRule
+      - events:CreateRule
+      - events:DeleteRule
     Resource:
       - 'arn:aws:events:{{ aws_region }}:{{ aws_account_id }}:rule:cloudwatch_event_rule*'
   - Sid: ModifyCloudwatchAlarms


### PR DESCRIPTION
I made a PR for Ansible AWS community collection that adds support for `InputTransformer` attribute of `cloudwatchevent_rule`.

This permission should allow the test to pass.

https://github.com/ansible-collections/community.aws/pull/623