### PR TITLE
Allow additional EFS actions required for integration tests

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -162,15 +162,19 @@ Statement:
       - elasticloadbalancing:RegisterTargets
       - elasticloadbalancing:SetSecurityGroups
       - elasticloadbalancing:SetWebACL
-      - elasticfilesystem:DescribeFileSystems
-      - elasticfilesystem:DescribeMountTargets
-      - elasticfilesystem:DescribeMountTargetSecurityGroups
-      - elasticfilesystem:DescribeTags
       - elasticfilesystem:CreateFileSystem
       - elasticfilesystem:CreateMountTarget
       - elasticfilesystem:CreateTags
       - elasticfilesystem:DeleteFileSystem
       - elasticfilesystem:DeleteMountTarget
+      - elasticfilesystem:DescribeFileSystems
+      - elasticfilesystem:DescribeMountTargets
+      - elasticfilesystem:DescribeMountTargetSecurityGroups
+      - elasticfilesystem:DescribeTags
+      - elasticfilesystem:ListTagsForResource
+      - elasticfilesystem:TagResource
+      - elasticfilesystem:UntagResource
+      - elasticfilesystem:UpdateFileSystem
     Resource:
       - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:launchConfiguration:*'
       - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*'


### PR DESCRIPTION
I'd like to enable integration tests for efs & new efs_tag modules / remove unsupported alias and hence I need to allow few more EFS actions.

https://github.com/ansible-collections/community.aws/pull/608

```
PLAY RECAP *********************************************************************************************************
localhost                  : ok=47   changed=14   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

AWS ACTIONS: ['ec2:CreateSubnet', 'ec2:CreateTags', 'ec2:CreateVpc', 'ec2:DeleteSubnet', 'ec2:DeleteVpc', 'ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets', 'ec2:DescribeTags', 'ec2:DescribeVpcAttribute', 'ec2:DescribeVpcClassicLink', 'ec2:DescribeVpcs', 'ec2:ModifyVpcAttribute', 'elasticfilesystem:CreateFileSystem', 'elasticfilesystem:CreateMountTarget', 'elasticfilesystem:CreateTags', 'elasticfilesystem:DeleteFileSystem', 'elasticfilesystem:DeleteMountTarget', 'elasticfilesystem:DescribeFileSystems', 'elasticfilesystem:DescribeMountTargetSecurityGroups', 'elasticfilesystem:DescribeMountTargets', 'elasticfilesystem:DescribeTags', 'elasticfilesystem:ListTagsForResource', 'elasticfilesystem:TagResource', 'elasticfilesystem:UntagResource', 'elasticfilesystem:UpdateFileSystem']
``` 

Thanks in advance