### PR TITLE
Ignore default RDS DB Parameter groups

### DIFF
--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -170,6 +170,10 @@ class RdsDbParameterGroup(DbTerminator):
     def name(self):
         return self.instance['DBParameterGroupName']
 
+    @property
+    def ignore(self):
+        return self.name.startswith('default')
+
     def terminate(self):
         self.client.delete_db_parameter_group(DBParameterGroupName=self.name)
 


### PR DESCRIPTION
AWS will let you create them (automatically), but not delete them.  No costs associated.

```
cleanup     : ERROR    {"message": "error \"InvalidDBParameterGroupState\" terminating RdsDbParameterGroup: name=default.oracle-ee-19, id=arn:aws:rds:us-east-1:000285366142:pg:default.oracle-ee-19 age=0:25:27, stale=True", "traceback": "Traceback (most recent call last):\n  File \"/home/mchappel/vcs/ansible/aws-terminator/aws/terminator/__init__.py\", line 138, in terminate\n    instance.terminate()\n  File \"/home/mchappel/vcs/ansible/aws-terminator/aws/terminator/data_services.py\", line 174, in terminate\n    self.client.delete_db_parameter_group(DBParameterGroupName=self.name)\n  File \"/home/mchappel/vcs/ansible/ansible-dev/lib/python3.6/site-packages/botocore/client.py\", line 316, in _api_call\n    return self._make_api_call(operation_name, kwargs)\n  File \"/home/mchappel/vcs/ansible/ansible-dev/lib/python3.6/site-packages/botocore/client.py\", line 626, in _make_api_call\n    raise error_class(parsed_response, operation_name)\nbotocore.errorfactory.InvalidDBParameterGroupStateFault: An error occurred (InvalidDBParameterGroupState) when calling the DeleteDBParameterGroup operation: Default DBParameterGroup cannot be deleted: default.oracle-ee-19"}
```