### PR TITLE
Ignore default RdsDbParameterGroups

### DIFF
--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -170,6 +170,10 @@ class RdsDbParameterGroup(DbTerminator):
     def name(self):
         return self.instance['DBParameterGroupName']
 
+    @property
+    def ignore(self):
+        return self.name.startswith('default')
+
     def terminate(self):
         self.client.delete_db_parameter_group(DBParameterGroupName=self.name)
 


### PR DESCRIPTION
They can't deleted - see `Constraints` in https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBParameterGroup.html