### PR TITLE
Bump collection dependency version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 collections:
   - name: mattclay.aws
-    version: '1.0.0'
+    version: '2.0.0'


### PR DESCRIPTION
We need 2.0.0 of mattclay.aws to deal with https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/ when publishing lambda updates