### PR TITLE
Allow all Describe for ASG

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -109,13 +109,11 @@ Statement:
           - t3.micro
           - m1.large  # lowest cost instance type with EBS optimization supported
 
+  # ASG and ELB don't like being region restricted.
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - autoscaling:DescribeAutoScalingGroups
-      - autoscaling:DescribeInstanceRefreshes
-      - autoscaling:DescribeLaunchConfigurations
-      - autoscaling:DescribePolicies
+      - autoscaling:Describe*
       - ec2:DescribeAvailabilityZones
       - elasticloadbalancing:DeleteRule
       - elasticloadbalancing:DeleteListener
@@ -146,8 +144,6 @@ Statement:
       - autoscaling:DeleteLaunchConfiguration
       - autoscaling:DeletePolicy
       - autoscaling:DeleteTags
-      - autoscaling:DescribeTags
-      - autoscaling:DescribeAdjustmentTypes
       - autoscaling:PutScalingPolicy
       - ec2:DeleteVolume
       - elasticloadbalancing:AddTags
@@ -181,10 +177,7 @@ Statement:
       - elasticfilesystem:CreateTags
       - elasticfilesystem:DeleteFileSystem
       - elasticfilesystem:DeleteMountTarget
-      - elasticfilesystem:DescribeFileSystems
-      - elasticfilesystem:DescribeMountTargets
-      - elasticfilesystem:DescribeMountTargetSecurityGroups
-      - elasticfilesystem:DescribeTags
+      - elasticfilesystem:Describe*
       - elasticfilesystem:ListTagsForResource
       - elasticfilesystem:TagResource
       - elasticfilesystem:UntagResource


### PR DESCRIPTION
There's no value playing whack-a-mole on the describe permissions.  (ASG IAM can't be region restricted - I tried)

I'm working on migrating elb_instance over to boto3 and I need ASGs for some tests.

https://github.com/ansible-collections/community.aws/pull/768