### PR TITLE
Add missing permissions for autoscaling

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -145,6 +145,8 @@ Statement:
       - autoscaling:DeletePolicy
       - autoscaling:DeleteTags
       - autoscaling:PutScalingPolicy
+      - autoscaling:PutScheduledUpdateGroupAction
+      - autoscaling:DeleteScheduledAction
       - ec2:DeleteVolume
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer


### PR DESCRIPTION
## Overview
Adding the required missing permissions to enable new integration tests for the new `ec2_asg_scheduled_action` module:
https://github.com/ansible-collections/community.aws/pull/779
https://dashboard.zuul.ansible.com/t/ansible/build/f17261c2b40e4e619bf38b69c58526da/console