### PR TITLE
Add policy for rds_export_task

### DIFF
--- a/aws/policy/data-services.yaml
+++ b/aws/policy/data-services.yaml
@@ -98,6 +98,9 @@ Statement:
       - rds:DeleteOptionGroup
       - rds:CreateDBSnapshot
       - rds:DeleteDBSnapshot
+      - rds:DescribeExportTasks
+      - rds:StartExportTask
+      - rds:CancelExportTask
     Resource:
       - 'arn:aws:dms:{{ aws_region }}:{{ aws_account_id }}:subgrp:*'
       - 'arn:aws:dynamodb:{{ aws_region }}:{{ aws_account_id }}:table/*'

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -150,7 +150,7 @@ Statement:
       - 'arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*'
       # This is hard coded into DMS...
       - 'arn:aws:iam::{{ aws_account_id }}:role/dms-vpc-role'
-      - 'arn:aws:sts::{{ aws_account_id }}:role/rds_export_task'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/rds_export_task'
   # This allows AWS Services to autmatically create their Default Service Linked Roles
   # These have fixed policies and can only be assumed by the service itself.
   - Sid: AllowServiceLinkedRoleCreation

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -150,6 +150,7 @@ Statement:
       - 'arn:aws:iam::{{ aws_account_id }}:role/ansible-test-*'
       # This is hard coded into DMS...
       - 'arn:aws:iam::{{ aws_account_id }}:role/dms-vpc-role'
+      - 'arn:aws:sts::{{ aws_account_id }}:role/rds_export_task'
   # This allows AWS Services to autmatically create their Default Service Linked Roles
   # These have fixed policies and can only be assumed by the service itself.
   - Sid: AllowServiceLinkedRoleCreation


### PR DESCRIPTION
Add policy for `rds_export_task`. Required by https://github.com/ansible-collections/community.aws/pull/761/files