### PR TITLE
Fix SSMBucketObjects handling of empty results

### DIFF
--- a/aws/terminator/storage_services.py
+++ b/aws/terminator/storage_services.py
@@ -51,7 +51,11 @@ class SSMBucketObjects(Terminator):
     @staticmethod
     def create(credentials):
         def paginate_objects(client):
-            return client.get_paginator('list_objects_v2').paginate(Bucket='ssm-encrypted-test-bucket').build_full_result()['Contents']
+            list_bucket_objects_result = client.get_paginator('list_objects_v2').paginate(Bucket='ssm-encrypted-test-bucket').build_full_result()
+            bucket_contents = dict()
+            if list_bucket_objects_result.get('Contents'):
+                bucket_contents = list_bucket_objects_result['Contents']
+            return bucket_contents
 
         return Terminator._create(credentials, SSMBucketObjects, 's3', paginate_objects)
 


### PR DESCRIPTION
We were not gracefully handling empty results to list_bcket_objects.  It's not clear if this changed on the API or not, cloduwatch logs seem to indicate we didn't see errors until 2022/01/04.