### PR TITLE
Add permissions to create and delete ec2 placement group

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -65,11 +65,13 @@ Statement:
       - ec2:CreateKeyPair
       - ec2:CreateLaunchTemplate
       - ec2:CreateLaunchTemplateVersion
+      - ec2:CreatePlacementGroup
       - ec2:CreateSnapshot
       - ec2:CreateTags
       - ec2:DeleteKeyPair
       - ec2:DeleteLaunchTemplate
       - ec2:DeleteLaunchTemplateVersions
+      - ec2:DeletePlacementGroup
       - ec2:DeleteSnapshot
       - ec2:DeleteTags
       - ec2:DeregisterImage


### PR DESCRIPTION
Added missing permissions to create and delete placement groups for  ```ec2_placement_group``` module for adding integration tests.