### PR TITLE
Add t2.nano to allowed autoscaling instance types

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -41,6 +41,7 @@ Statement:
         autoscaling:InstanceTypes:
           - t3.nano
           - t3.micro
+          - t2.nano
 
   # Permit RunInstance to access any of the usual objects attached to an
   # instance

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -35,7 +35,7 @@ Statement:
       - autoscaling:EnableMetricsCollection
       - autoscaling:TerminateInstanceInAutoScalingGroup
     Resource:
-      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*'
+      - 'arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup*'
     Condition:
       StringEqualsIfExists:
         autoscaling:InstanceTypes:


### PR DESCRIPTION
Added missing instance type ```t2.nano``` for ec2_asg integration tests.