### PR TITLE
feat: add permissions to create and delete SSM documents

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -93,6 +93,9 @@ Statement:
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - ssm:CreateDocument
+      - ssm:DeleteDocument
+      - ssm:ListDocuments
       - cloudformation:CreateChangeSet
       - cloudformation:CreateStack
       - cloudformation:DeleteChangeSet
@@ -159,6 +162,7 @@ Statement:
       - states:TagResource
       - states:UntagResource
     Resource:
+      - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:document/*'
       - 'arn:aws:cloudformation:{{ aws_region }}:{{ aws_account_id }}:stack/*'
       - 'arn:aws:cloudwatch:{{ aws_region }}:{{ aws_account_id }}:alarm:*'
       - 'arn:aws:codebuild:{{ aws_region }}:{{ aws_account_id }}:*'

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -75,6 +75,7 @@ Statement:
       - ssm:GetDocument
       - ssm:GetManifest
       - ssm:ListAssociations
+      - ssm:ListDocuments
       - ssm:ListInstanceAssociations
       - ssmmessages:CreateControlChannel
       - ssmmessages:CreateDataChannel
@@ -95,7 +96,6 @@ Statement:
     Action:
       - ssm:CreateDocument
       - ssm:DeleteDocument
-      - ssm:ListDocuments
       - cloudformation:CreateChangeSet
       - cloudformation:CreateStack
       - cloudformation:DeleteChangeSet

--- a/aws/terminator/application_services.py
+++ b/aws/terminator/application_services.py
@@ -345,3 +345,25 @@ class CloudWatchAlarm(DbTerminator):
 
     def terminate(self):
         self.client.delete_alarms(AlarmNames=[self.name])
+
+
+class SsmDocument(Terminator):
+    @staticmethod
+    def create(credentials):
+        def get_ssm_documents(client):
+            ssm_documents = client.get_paginator(
+                'list_documents').paginate(Filters=[{'Key': 'Owner', 'Values': ['self']}]).build_full_result().get('DocumentIdentifiers', [])
+            return ssm_documents
+
+        return Terminator._create(credentials, SsmDocument, 'ssm', get_ssm_documents)
+
+    @property
+    def created_time(self):
+        return self.instance['CreatedDate']
+
+    @property
+    def name(self):
+        return self.instance['Name']
+
+    def terminate(self):
+        self.client.delete_document(Name=self.name)


### PR DESCRIPTION
Hello,

I'm adding support for SSM documents when using the Ansible's SSM connection plugin, and there's a need to be able to create and delete SSM documents during CI, hence this PR. You can find the Ansible PR here: https://github.com/ansible-collections/community.aws/pull/876

Extract from the job log:

```
An error occurred (AccessDeniedException) when calling the CreateDocument operation: User: arn:aws:sts::966509639900:assumed-role/ansible-core-ci-test-prod/prod=remote=zuul-cloud is not authorized to perform: ssm:CreateDocument on resource: arn:aws:ssm:us-east-1:966509639900:document/ansible-custom-document because no identity-based policy allows the ssm:CreateDocument action
```

Thanks a lot in advance