### PR TITLE
ASG: Add policy for ASG detach instances

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -9,6 +9,7 @@ Statement:
       - autoscaling:CreateAutoScalingGroup
       - autoscaling:CreateLaunchConfiguration
       - autoscaling:UpdateAutoScalingGroup
+      - autoscaling:DetachInstances
       - ec2:RunInstances
       - ec2:StartInstances
     Resource:


### PR DESCRIPTION
Add required policy to allow AutoScalingGroup Detach Instances action.

Currently integration test for ASG Detach Instances feature throws AccessDenied error:
```
TASK [ec2_asg : detach 2 instance from the asg and replace with other instances] ******************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: 
An error occurred (AccessDenied) when calling the DetachInstances operation: User: arn:aws:sts::xxxxxx:assumed-role/ansible-
core-ci-xxx-xxxx/prod=remote=xxxxx is not authorized to perform: autoscaling:DetachInstances on resource: 
arn:aws:autoscaling:us-east-1:xxxxx:autoScalingGroup:c6baca75-c880-41cd-xxx-xxxxxx:autoScalingGroupName/ansible-test-
xxxx-localhost-asg-detach-test because no identity-based policy allows the autoscaling:DetachInstances action
``` 

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/autoscaling.html#AutoScaling.Client.detach_instances

https://docs.aws.amazon.com/autoscaling/ec2/userguide/detach-instance-asg.html