### PR TITLE
Update requirements

### DIFF
--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,9 +1,12 @@
-boto3==1.15.18
-botocore==1.18.18  # 1.19.0 (and boto3 1.16.0) requires a urllib3 update
-docutils==0.14
-jmespath==0.9.4
-python-dateutil==2.8.0
-requests==2.22.0
-s3transfer==0.3.0
-six==1.12.0
-urllib3==1.24.3
+boto3==1.21.10
+botocore==1.24.10
+certifi==2021.10.8
+charset-normalizer==2.0.12
+docutils==0.18.1
+idna==3.3
+jmespath==0.10.0
+python-dateutil==2.8.2
+requests==2.27.1
+s3transfer==0.5.2
+six==1.16.0
+urllib3==1.26.8


### PR DESCRIPTION
The recent network-firewall changes require a newer version of botocore. This upgrade triggers a cascade of updates for the other requirements. The lambda runs without errors from a clean virtualenv with these requirements.