### PR TITLE
Add aws_eks_fargate_profile permissions 

### DIFF
--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -36,6 +36,12 @@ Statement:
       - eks:DeleteCluster
       - eks:DescribeCluster
       - eks:ListClusters
+      - eks:CreateFargateProfile
+      - eks:DeleteFargateProfile
+      - eks:DescribeFargateProfile
+      - eks:ListFargateProfiles
+      - eks:ListTagsForResource
+      - eks:UntagResource
       - elasticbeanstalk:CreateApplication
       - elasticbeanstalk:DeleteApplication
       - elasticbeanstalk:DescribeApplications
@@ -70,6 +76,7 @@ Statement:
     Resource:
       - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
+      - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:fargateprofile/*/*/*'
       - 'arn:aws:elasticbeanstalk:{{ aws_region }}:{{ aws_account_id }}:application/*'
       - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
       - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -41,6 +41,7 @@ Statement:
       - eks:DescribeFargateProfile
       - eks:ListFargateProfiles
       - eks:ListTagsForResource
+      - eks:TagResource
       - eks:UntagResource
       - elasticbeanstalk:CreateApplication
       - elasticbeanstalk:DeleteApplication

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -14,6 +14,9 @@ Statement:
       ArnLike:
         iam:PolicyArn:
           - 'arn:aws:iam::aws:policy/AWSDenyAll'
+          - 'arn:aws:iam::aws:policy/AmazonEKSServicePolicy'
+          - 'arn:aws:iam::aws:policy/AmazonEKSClusterPolicy'
+          - 'arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy'
           - 'arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess'
           - 'arn:aws:iam::aws:policy/IAMReadOnlyAccess'
           - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
@@ -165,8 +168,10 @@ Statement:
     Resource:
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/autoscaling.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/spot.amazonaws.com/*'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/eks-fargate.amazonaws.com/*'
     Condition:
       ForAnyValue:StringEquals:
         iam:AWSServiceName:
           - 'autoscaling.amazonaws.com'
           - 'spot.amazonaws.com'
+          - 'eks-fargate.amazonaws.com'

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -303,7 +303,7 @@ class EksCluster(Terminator):
     def created_time(self):
         return self.instance['createdAt']
 
-    #EKS Fargate Profile is cluster dependent and can only be listed or described through it.
+    # EKS Fargate Profile is cluster dependent and can only be listed or described through it.
     def _find_eks_fargate_profile(self):
         return self.client.list_fargate_profiles(clusterName=self.name)['fargateProfileNames']
 


### PR DESCRIPTION
Permissions to new module PR [ansible-collections/community.aws/#942](https://github.com/ansible-collections/community.aws/pull/942)

**ADDITIONAL INFORMATION**
1 - I implemented Terminator in EksCluster class because it is a dependent resource and it only works with a created cluster.
2 - It was necessary to implement a waiter because if there is a fargate in process of deletion, the cluster delete fails.


