### PR TITLE
add ssm:DeleteDocument

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -30,6 +30,7 @@ Statement:
       - ssm:GetDeployablePatchSnapshotForInstance
       - ssm:GetDocument
       - ssm:DescribeDocument
+      - ssm:DeleteDocument
       - ssm:GetManifest
       - ssm:ListAssociations
       - ssm:ListInstanceAssociations


### PR DESCRIPTION
Required by https://github.com/ansible-collections/community.aws/pull/876

```
"An error occurred (AccessDeniedException) when calling the DeleteDocument operation:  
User: arn:aws:sts::966509639900:assumed-role/ansible-core-ci-test-prod/prod=remote=zuul-cloud is not authorized to perform:  
ssm:DeleteDocument on resource: arn:aws:ssm:us-east-1:966509639900:document/ansible-custom-document because no identity-based policy allows the ssm:DeleteDocument action"
```