### PR TITLE
ASG: Add policy for ASG create/delete Lifecycle Hooks

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -141,10 +141,12 @@ Statement:
       - autoscaling:DeleteScheduledAction
       - autoscaling:DeleteTags
       - autoscaling:DetachLoadBalancers
+      - autoscaling:DeleteLifecycleHook
       - autoscaling:DetachLoadBalancerTargetGroups
       - autoscaling:DisableMetricsCollection
       - autoscaling:PutScalingPolicy
       - autoscaling:PutScheduledUpdateGroupAction
+      - autoscaling:PutLifecycleHook
       - autoscaling:StartInstanceRefresh
       - autoscaling:TerminateInstanceInAutoScalingGroup
       - ec2:DeleteVolume


### PR DESCRIPTION
Add required policy to allow AutoScalingGroup create/delete Lifecycle Hooks.

 [ec2_asg_lifecycle_hook module](https://github.com/ansible-collections/community.aws/blob/main/plugins/modules/ec2_asg_lifecycle_hook.py) does not have integration tests currently.

Writing up integration tests for [ec2_asg_lifecycle_hook module](https://github.com/ansible-collections/community.aws/blob/main/plugins/modules/ec2_asg_lifecycle_hook.py), integration test throws AccessDenied error:
```

An error occurred (AccessDenied) when calling the PutLifecycleHook operation: User: arn:aws:sts::xxxxx:assumed-role/ansible-
core-ci-test-prod/prod=remote=mandkulk is not authorized to perform: autoscaling:PutLifecycleHook on resource: 
arn:aws:autoscaling:us-east-1:xxxx:autoScalingGroup:xxxxx-ad64-4d59-8010-xxxxxx:autoScalingGroupName/ansible-test-xxxxxx-
localhost-asg because no identity-based policy allows the autoscaling:PutLifecycleHook action

```
PR: https://github.com/ansible-collections/community.aws/pull/1048


API References:

- https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PutLifecycleHook.html
- https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DeleteLifecycleHook.html