### PR TITLE
Allow logs:ListLogDeliveries

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -85,6 +85,7 @@ Statement:
       - glue:GetConnections
       - glue:GetCrawlers
       - glue:GetJobs
+      - logs:ListLogDeliveries
     Resource: "*"
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow


### PR DESCRIPTION
Working on https://github.com/ansible-collections/community.aws/pull/1107 I've discovered that even if you don't configure logging, you need to be able to **list** the logging configuration to delete NetworkFirewall firewalls