### PR TITLE
Allow creation of the NetworkFirewall service role

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -171,6 +171,7 @@ Statement:
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/spot.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/eks-fargate.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/transitgateway.amazonaws.com/*'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/network-firewall.amazonaws.com/*'
     Condition:
       ForAnyValue:StringEquals:
         iam:AWSServiceName:
@@ -178,3 +179,4 @@ Statement:
           - 'spot.amazonaws.com'
           - 'eks-fargate.amazonaws.com'
           - 'transitgateway.amazonaws.com'
+          - 'network-firewall.amazonaws.com'


### PR DESCRIPTION
For the first run the service needs to be able to create it's Service Role.

(at least there was an error message)

https://docs.aws.amazon.com/network-firewall/latest/developerguide/using-service-linked-roles.html


https://9671121b71c0abd50cf8-b0c6c8b84192f9d1d6d6ba67caeaf655.ssl.cf1.rackcdn.com/1107/40e9e1c713d73f7856becd8a681e16a8f9db9455/check/integration-community.aws-1/093c14e/job-output.txt

```
2022-05-17 16:19:51.757466 | controller |     "msg": "Failed to create firewall: An error occurred (AccessDeniedException) when calling the CreateFirewall operation: Unable to CreateFirewall because user is not authorized perform iam:CreateServiceLinkedRole",
```