### PR TITLE
Allow GetParameter on SSM resources we've created

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -145,6 +145,7 @@ Statement:
       - SNS:Subscribe
       - SNS:Unsubscribe
       - ssm:DeleteParameter
+      - ssm:GetParameter
       - ssm:GetParameters
       - ssm:GetParametersByPath
       - ssm:PutParameter


### PR DESCRIPTION
https://github.com/ansible-collections/amazon.aws/pull/873 - some of the later tests will probably still fail due to the same issue as https://github.com/ansible-collections/amazon.aws/pull/810