### PR TITLE
Do not delete automated RDS backups

### DIFF
--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -196,13 +196,15 @@ class RdsDbInstance(DbTerminator):
         return datetime.timedelta(minutes=60)
 
     def terminate(self):
+        self.client.modify_db_instance(DBInstanceIdentifier=self.name, BackupRetentionPeriod=0)
         self.client.delete_db_instance(DBInstanceIdentifier=self.name, SkipFinalSnapshot=True)
 
 
 class RdsDbSnapshot(DbTerminator):
     @staticmethod
     def create(credentials):
-        return Terminator._create(credentials, RdsDbSnapshot, 'rds', lambda client: client.describe_db_snapshots(SnapshotType='manual')['DBSnapshots'])
+        return Terminator._create(credentials, RdsDbSnapshot, 'rds',
+                                   lambda client: client.describe_db_snapshots(SnapshotType='manual')['DBSnapshots'])
 
     @property
     def id(self):
@@ -238,13 +240,15 @@ class RdsDbCluster(Terminator):
         return self.instance['ClusterCreateTime']
 
     def terminate(self):
+        self.client.modify_db_cluster(DBClusterIdentifier=self.name, BackupRetentionPeriod=1)
         self.client.delete_db_cluster(DBClusterIdentifier=self.name, SkipFinalSnapshot=True)
 
 
 class RdsDbClusterSnapshot(Terminator):
     @staticmethod
     def create(credentials):
-        return Terminator._create(credentials, RdsDbClusterSnapshot, 'rds', lambda client: client.describe_db_cluster_snapshots(SnapshotType='manual')['DBClusterSnapshots'])
+        return Terminator._create(credentials, RdsDbClusterSnapshot, 'rds',
+                                  lambda client: client.describe_db_cluster_snapshots(SnapshotType='manual')['DBClusterSnapshots'])
 
     @property
     def id(self):

--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -202,7 +202,7 @@ class RdsDbInstance(DbTerminator):
 class RdsDbSnapshot(DbTerminator):
     @staticmethod
     def create(credentials):
-        return Terminator._create(credentials, RdsDbSnapshot, 'rds', lambda client: client.describe_db_snapshots()['DBSnapshots'])
+        return Terminator._create(credentials, RdsDbSnapshot, 'rds', lambda client: client.describe_db_snapshots(SnapshotType='manual')['DBSnapshots'])
 
     @property
     def id(self):
@@ -244,7 +244,7 @@ class RdsDbCluster(Terminator):
 class RdsDbClusterSnapshot(Terminator):
     @staticmethod
     def create(credentials):
-        return Terminator._create(credentials, RdsDbClusterSnapshot, 'rds', lambda client: client.describe_db_cluster_snapshots()['DBClusterSnapshots'])
+        return Terminator._create(credentials, RdsDbClusterSnapshot, 'rds', lambda client: client.describe_db_cluster_snapshots(SnapshotType='manual')['DBClusterSnapshots'])
 
     @property
     def id(self):

--- a/aws/terminator/data_services.py
+++ b/aws/terminator/data_services.py
@@ -204,7 +204,7 @@ class RdsDbSnapshot(DbTerminator):
     @staticmethod
     def create(credentials):
         return Terminator._create(credentials, RdsDbSnapshot, 'rds',
-                                   lambda client: client.describe_db_snapshots(SnapshotType='manual')['DBSnapshots'])
+                                  lambda client: client.describe_db_snapshots(SnapshotType='manual')['DBSnapshots'])
 
     @property
     def id(self):


### PR DESCRIPTION
Automated RDS backups can't be manually deleted. They will get removed
once the instance/cluster is deleted.