### PR TITLE
Allow policy validation API access

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -66,6 +66,7 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - access-analyzer:ValidatePolicy
       - iam:GetRole
       - iam:ListAttachedRolePolicies
       - iam:ListRoles


### PR DESCRIPTION
AWS now have an API for validating and linting policy documents:

https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_ValidatePolicy.html

https://github.com/ansible-collections/community.aws/pull/1370