### PR TITLE
LaunchConfiguration: increate age_limit

### DIFF
--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -554,6 +554,10 @@ class LaunchConfiguration(Terminator):
         )
 
     @property
+    def age_limit(self):
+        return datetime.timedelta(minutes=30)
+
+    @property
     def id(self):
         return self.instance['LaunchConfigurationName']
 


### PR DESCRIPTION
Extend age limit of LaunchConfig resources to 30 minutes. The default value
is too low and triggers job failure.

e.g: https://f596750bccc3c2307b10-d5be670428ac58538376880bfd46a6ea.ssl.cf5.rackcdn.com/1468/cc9cf556d6a893fd1dfeb056c86cb46336904c0e/check/integration-community.aws-1/f608f0e/job-output.txt
