### PR TITLE
EC2: Add policy to get instance UEFI data

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -67,6 +67,7 @@ Statement:
       - ec2:DetachVolume
       - ec2:DisassociateIamInstanceProfile
       - ec2:GetLaunchTemplateData
+      - ec2:GetInstanceUefiData
       - ec2:ImportKeyPair
       - ec2:ModifyImageAttribute
       - ec2:ModifyInstanceAttribute


### PR DESCRIPTION
Added missing permissions to get instance uefi data for `ec2_ami` module for adding integration tests.

Task to get uefi data in integration tests: https://github.com/ansible-collections/amazon.aws/pull/1037/files#diff-ceba09bf3546fc4c878b0ae63333fa702ef39a1c13fb206f78333031fd67dc07R77-R86

API reference: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetInstanceUefiData.html