### PR TITLE
update terminator.yml to use boto3 modules (iam_role)

### DIFF
--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -28,17 +28,11 @@
         that: "aws_account_id == lambda_account_id"
     - name: create iam role for terminator functions
       tags: iam
-      iam:
-        iam_type: role
+      community.aws.iam_role:
         name: "{{ api_name }}-terminator-{{ stage }}"
+        description: "iam role for terminator functions"
         state: present
-        trust_policy:
-          Version: '2012-10-17'
-          Statement:
-            - Action: sts:AssumeRole
-              Effect: Allow
-              Principal:
-                Service: lambda.amazonaws.com
+        assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "lambda.amazonaws.com"}, "Effect":"Allow"}}'
     - name: create iam policy for terminator functions
       tags: iam
       iam_policy:

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -32,7 +32,13 @@
         name: "{{ api_name }}-terminator-{{ stage }}"
         description: "iam role for terminator functions"
         state: present
-        assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "lambda.amazonaws.com"}, "Effect":"Allow"}}'
+        assume_role_policy_document:
+          Version: "2012-10-17"
+          Statement:
+            Action: "sts:AssumeRole"
+            Principal:
+              Service": "lambda.amazonaws.com"
+            Effect: "Allow"
     - name: create iam policy for terminator functions
       tags: iam
       iam_policy:

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -37,7 +37,7 @@
           Statement:
             Action: "sts:AssumeRole"
             Principal:
-              Service": "lambda.amazonaws.com"
+              Service: "lambda.amazonaws.com"
             Effect: "Allow"
     - name: create iam policy for terminator functions
       tags: iam

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@ collections:
   - name: mattclay.aws
     version: '2.0.0'
   - name: community.aws
-    version: '1.4.0'
+    version: '3.3.0'

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 collections:
   - name: mattclay.aws
     version: '2.0.0'
+  - name: community.aws
+    version: '1.4.0'


### PR DESCRIPTION
``aws/terminator.yml`` is using the ``community.aws.iam`` module which was previously deprecated, and then removed in 3.0.0.
update playbook to use ``community.aws.iam_role`` module