### PR TITLE
Use unrestricted permissions for listing certs

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -73,6 +73,7 @@ Statement:
       - iam:ListRolePolicies
       - iam:ListRoleTags
       - iam:ListSAMLProviders
+      - iam:ListServerCertificates
       - iam:TagRole
       - iam:UntagRole
       - kms:CreateAlias
@@ -147,7 +148,6 @@ Statement:
       - iam:GetSAMLProvider
       - iam:GetServerCertificate
       - iam:ListInstanceProfilesForRole
-      - iam:ListServerCertificates
       - iam:PassRole
       - iam:RemoveRoleFromInstanceProfile
       - iam:UpdateSAMLProvider


### PR DESCRIPTION
There's no way to filter certs by Arn when making a list call, so the permissions need to allow for unrestricted listing.