### PR TITLE
Increase lambda timeout

### DIFF
--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -100,7 +100,7 @@
         name: "{{ api_name }}-terminator"
         local_path: "{{ packaging_dir }}/terminator.zip"
         runtime: python3.7
-        timeout: 60
+        timeout: 120
         handler: terminator_lambda.lambda_handler
         memory_size: 128
         role: "{{ api_name }}-terminator-{{ stage }}"


### PR DESCRIPTION
When the testing load is high, the lambda struggles to get through all the resources in the currently alloted 60 seconds. While the resources are eventually cleaned up, it can lead to intermittent quota and test failures. This increases the timeout to 2 minutes.