### PR TITLE
IAM: Add managed policies required for lambda_event integration tests

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -25,8 +25,8 @@ Statement:
           - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
           - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole'
           - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-          - arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole
-          - arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB
+          - 'arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole'
+          - 'arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB'
           - 'arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole'
           - 'arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole'
           - 'arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole'

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -25,6 +25,8 @@ Statement:
           - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
           - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole'
           - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole
+          - arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB
           - 'arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole'
           - 'arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole'
           - 'arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole'


### PR DESCRIPTION
PR: https://github.com/ansible-collections/amazon.aws/pull/1209

Failing Task: https://github.com/ansible-collections/amazon.aws/pull/1209/files#diff-798b8e86233576ca7ca0283da2102a902424f9d5feb64cc08b643ed3f325a5b4R37-R46


### Additional Info

`lambda_event` [Integration test task](https://github.com/ansible-collections/amazon.aws/pull/1209/files#diff-798b8e86233576ca7ca0283da2102a902424f9d5feb64cc08b643ed3f325a5b4R37-R46) in integration [tests for lambda_event](https://github.com/ansible-collections/amazon.aws/pull/1209/files) creates an iam role with `managed_policies` required to provide lambda function access of dynamo db stream to create a trigger

But the task fails on CI run with
```
"code": "AccessDenied",
"message": "User: arn:aws:sts::966509639900:assumed-role/ansible-core-ci-test-prod/prod=remote=zuul-cloud 
is not authorized to perform: iam:AttachRolePolicy on resource: role ansible-test-252b7c576fb5-lambda because 
no identity-based policy allows the iam:AttachRolePolicy action",
```
Although [aws-terminator has iam:AttachRolePolicy](https://github.com/mattclay/aws-terminator/blob/master/aws/policy/security-services.yaml#L4-L31) , only managed policies allowed are the ones specified here

So we need need below managed policies added for integration tests to succeed.
```
arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB
arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole
```
