### PR TITLE
address a couple of Flake8 errors

### DIFF
--- a/aws/cleanup.py
+++ b/aws/cleanup.py
@@ -50,7 +50,7 @@ def main():
 
     yaml.add_multi_constructor('', default_ctor)
 
-    with open(config_path) as config_fd:
+    with open(config_path, encoding="utf-8") as config_fd:
         config = yaml.load(config_fd, Loader=yaml.BaseLoader)
 
     test_account_id = config['test_account_id']

--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -270,7 +270,7 @@ class Terminator(abc.ABC):
 class DbTerminator(Terminator):
     """Base class for classes which find and terminate AWS resources with age tracked via DynamoDB."""
     def __init__(self, client: botocore.client.BaseClient, instance: typing.Dict[str, typing.Any]):
-        super(DbTerminator, self).__init__(client, instance)
+        super().__init__(client, instance)
 
         self._kvs_key = None
         self._kvs_value = None

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -192,9 +192,7 @@ class Ec2TransitGatewayAttachment(Terminator):
 
     @property
     def name(self):
-        return "{0}/{1}".format(
-            self.instance['TransitGatewayId'],
-            self.instance['ResourceId'])
+        return f"{self.instance['TransitGatewayId']}/{self.instance['ResourceId']}"
 
     @property
     def created_time(self):

--- a/aws/terminator/networking.py
+++ b/aws/terminator/networking.py
@@ -139,7 +139,7 @@ class Ec2Subnet(DbTerminator):
 class Ec2InternetGateway(DbTerminator):
     def __init__(self, client, instance):
         self._ignore = None
-        super(Ec2InternetGateway, self).__init__(client, instance)
+        super().__init__(client, instance)
 
     @staticmethod
     def create(credentials):
@@ -161,7 +161,7 @@ class Ec2InternetGateway(DbTerminator):
     def ignore(self):
         if self._ignore is None:
             attachments = self._find_vpc_attachments()
-            self._ignore = any([self.is_vpc_default(attachment_id) for attachment_id in attachments])
+            self._ignore = any(self.is_vpc_default(attachment_id) for attachment_id in attachments)
         return self._ignore
 
     def _find_vpc_attachments(self):
@@ -269,7 +269,7 @@ class Ec2RouteTable(DbTerminator):
         # The main route table of a VPC cannot be deleted.
         # See: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
         # They will be removed when the VPC is deleted.
-        return any([association['Main'] for association in self.instance.get('Associations', [])])
+        return any(association['Main'] for association in self.instance.get('Associations', []))
 
     def terminate(self):
         for association in self.instance.get('Associations', []):

--- a/aws/terminator/storage_services.py
+++ b/aws/terminator/storage_services.py
@@ -52,7 +52,7 @@ class SSMBucketObjects(Terminator):
     def create(credentials):
         def paginate_objects(client):
             list_bucket_objects_result = client.get_paginator('list_objects_v2').paginate(Bucket='ssm-encrypted-test-bucket').build_full_result()
-            bucket_contents = dict()
+            bucket_contents = {}
             if list_bucket_objects_result.get('Contents'):
                 bucket_contents = list_bucket_objects_result['Contents']
             return bucket_contents


### PR DESCRIPTION
See: https://github.com/mattclay/aws-terminator/pull/239#discussion_r1019912793

- aws/cleanup.py:53:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
- aws/terminator/__init__.py:273:8: R1725: Consider using Python 3 style super() without arguments (super-with-arguments)
- aws/terminator/compute.py:195:15: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
- aws/terminator/networking.py:142:8: R1725: Consider using Python 3 style super() without arguments (super-with-arguments)
- aws/terminator/networking.py:164:27: R1729: Use a generator instead 'any(self.is_vpc_default(attachment_id) for attachment_id in attachments)' (use-a-generator)
- aws/terminator/networking.py:272:15: R1729: Use a generator instead 'any(association['Main'] for association in self.instance.get('Associations', []))' (use-a-generator)
- aws/terminator/storage_services.py:55:30: R1735: Consider using {} instead of dict() (use-dict-literal)
