### PR TITLE
yamllint: address a couple of comments-indentation warnings

### DIFF
--- a/hacking/aws_config/test_policies/container-policy.yaml
+++ b/hacking/aws_config/test_policies/container-policy.yaml
@@ -27,16 +27,16 @@ Statement:
       - ecs:StopTask
     Resource: "*"
 
-  # - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #   Resource:
-  #     -
+#  - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
+#    Effect: Allow
+#    Action:
+#      -
+#    Resource:
+#      -
 
-  # - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #   Resource:
-  #     -
+#  - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
+#    Effect: Allow
+#    Action:
+#      -
+#    Resource:
+#      -

--- a/hacking/aws_config/test_policies/devops-policy.yaml
+++ b/hacking/aws_config/test_policies/devops-policy.yaml
@@ -12,16 +12,16 @@ Statement:
       - codecommit:*Repository
     Resource: "*"
 
-  # - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #   Resource:
-  #    -
+#  - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
+#    Effect: Allow
+#    Action:
+#      -
+#    Resource:
+#     -
 
-  # - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #    Resource:
-  #     -
+#  - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
+#    Effect: Allow
+#    Action:
+#      -
+#     Resource:
+#      -

--- a/hacking/aws_config/test_policies/networking.yaml
+++ b/hacking/aws_config/test_policies/networking.yaml
@@ -28,16 +28,16 @@ Statement:
       - cloudfront:UpdateDistribution
     Resource: '*'
 
-  # - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #   Resource:
-  #     -
+#  - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
+#    Effect: Allow
+#    Action:
+#      -
+#    Resource:
+#      -
 
-  # - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #   Resource:
-  #     -
+#  - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
+#    Effect: Allow
+#    Action:
+#      -
+#    Resource:
+#      -

--- a/hacking/aws_config/test_policies/storage.yaml
+++ b/hacking/aws_config/test_policies/storage.yaml
@@ -25,10 +25,10 @@ Statement:
       - 'arn:aws:s3:::ansible-test-*'
       - 'arn:aws:s3:::ansible-test-*/*'
 
-  # - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
-  #   Effect: Allow
-  #   Action:
-  #     -
-  #   Resource:
-  #     - 'arn:aws:s3:::ansible-test-*'
-  #     - 'arn:aws:s3:::ansible-test-*/*'
+#  - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
+#    Effect: Allow
+#    Action:
+#      -
+#    Resource:
+#      - 'arn:aws:s3:::ansible-test-*'
+#      - 'arn:aws:s3:::ansible-test-*/*'


### PR DESCRIPTION
```
./hacking/aws_config/test_policies/container-policy.yaml
  30:3      warning  comment not indented like content  (comments-indentation)

./hacking/aws_config/test_policies/devops-policy.yaml
  15:3      warning  comment not indented like content  (comments-indentation)

./hacking/aws_config/test_policies/networking.yaml
  31:3      warning  comment not indented like content  (comments-indentation)

./hacking/aws_config/test_policies/storage.yaml
  28:3      warning  comment not indented like content  (comments-indentation)
```
