### PR TITLE
use Python 3.9

### DIFF
--- a/aws/Makefile
+++ b/aws/Makefile
@@ -1,4 +1,4 @@
-PYTHON3 ?= python3.7
+PYTHON3 ?= python3.9
 
 EXTRA_VARS=ansible_connection=local ansible_python_interpreter=$(shell which python)
 RUN_TEST_POLICY_PLAYBOOK=ansible-playbook -i localhost, -e '$(EXTRA_VARS)' deploy-test-policy.yml $(FLAGS)

--- a/aws/README.md
+++ b/aws/README.md
@@ -70,7 +70,7 @@ Warning: Always use the --check (or -c) flag and the --target flag to avoid acci
 It is safest to use `cleanup.py` in an empty/dev account.
 
 To start using `cleanup.py` you will need to:
-* Use Python 3.7+
+* Use Python 3.9
 * Modify config.yml to use your own accounts. These can be the same account if you're just using `cleanup.py`.
   If you use two separate accounts, `lambda_account_id` is the account of the profile that will assume the IAM role in the `test_account_id`. The `test_account_id` is where the terminator class(es) will locate/remove resources.
 * Create a role called `ansible-core-ci-test-dev` that your AWS profile can assume. Give this role the permissions required by the terminator class you are testing.

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -52,34 +52,34 @@
       pip:
         requirements: "{{ playbook_dir }}/requirements.txt"
         virtualenv: "{{ packaging_dir }}/terminator-requirements/python"
-        virtualenv_python: python3.7
+        virtualenv_python: python3.9
     - name: package terminator requirements
       tags: lambda
       lambda_package:
         src: "{{ packaging_dir }}/terminator-requirements"
         dest: "{{ packaging_dir }}/terminator-requirements.zip"
         include:
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/*"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/*"
         exclude:
           # pre-compiled bytecode
           - "*.pyc"
           # packaging information not needed at runtime
           - "*.dist-info/*"
           # only used for botocore documentation generation
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/docutils/*"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/docutils/*"
           # installed during creation of the virtualenv
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/pip/*"
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/wheel/*"
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/setuptools/*"
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/pkg_resources/*"
-          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.7/site-packages/easy_install.py"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/pip/*"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/wheel/*"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/setuptools/*"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/pkg_resources/*"
+          - "{{ packaging_dir }}/terminator-requirements/python/lib/python3.9/site-packages/easy_install.py"
     - name: publish terminator requirements layer
       tags: lambda
       lambda_layer:
         name: "{{ api_name }}-terminator-requirements"
         description: "Python requirements for {{ api_name }}-terminator"
         compatible_runtimes:
-          - python3.7
+          - python3.9
         path: "{{ packaging_dir }}/terminator-requirements.zip"
         license_info: GPL-3.0-only
         region: "{{ aws_region }}"
@@ -99,7 +99,7 @@
         region: "{{ aws_region }}"
         name: "{{ api_name }}-terminator"
         local_path: "{{ packaging_dir }}/terminator.zip"
-        runtime: python3.7
+        runtime: python3.9
         timeout: 120
         handler: terminator_lambda.lambda_handler
         memory_size: 128

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,8 @@ pool:
 steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
-    displayName: Install Python 3.7
+      versionSpec: '3.9'
+    displayName: Install Python 3.9
   - script: pip install --user tox
     displayName: Install tox
   - script: tox --notest


### PR DESCRIPTION
Upgrade the default Python version. Run the `policy` check by default now we've got a Python version that is compatible with an up to date `ansible-core` release.
