### PR TITLE
Increase memory allocation for lambda

### DIFF
--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -102,7 +102,7 @@
         runtime: python3.9
         timeout: 120
         handler: terminator_lambda.lambda_handler
-        memory_size: 128
+        memory_size: 256
         role: "{{ api_name }}-terminator-{{ stage }}"
         publish: True
         qualifier: "{{ stage }}"


### PR DESCRIPTION
We've been hitting timeouts with the latest deployment, and running close to 128MB for some time. 