### PR TITLE
Allow querying of /aws/service parameters

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -177,6 +177,7 @@ Statement:
       - 'arn:aws:sns:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:sqs:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:parameter/*'
+      - 'arn:aws:ssm:{{ aws_region }}::parameter/aws/service/*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
 
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees


### PR DESCRIPTION
SSM Parameters "/aws/service/*" are where Amazon publish official information about various AMIs

https://aws.amazon.com/blogs/compute/using-system-manager-parameter-as-an-alias-for-ami-id/