### PR TITLE
Add ListStacks

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -15,6 +15,7 @@ Statement:
       - cloudformation:ListExports
       - cloudformation:ListResourceRequests
       - cloudformation:ListResources
+      - cloudformation:ListStacks
       - cloudformation:UpdateResource
       ###
       - codebuild:BatchGetProjects
@@ -105,7 +106,6 @@ Statement:
       - cloudformation:DeleteStack
       - cloudformation:DescribeChangeSet
       - cloudformation:DescribeStackEvents
-      - cloudformation:DescribeStacks
       - cloudformation:GetStackPolicy
       - cloudformation:GetTemplate
       - cloudformation:ListChangeSets


### PR DESCRIPTION
Got the following warning from AWS (related to $DayJob) and want to avoid CI magically breaking:

> On January 25, 2023, we updated our DescribeStacks API as part of our continuous improvements to ensure customers have granular control over the APIs they use.
> 
> We require your action to update IAM Policies in your account by March 27, 2023 to avoid disruption to your DescribeStacks API calls.
> 
> AWS CloudFormation now requires that customers have the cloudformation:ListStacks permission when calling DescribeStacks[1] without a target stack. This is in addition to the cloudformation:DescribeStacks permission that is already a requirement. You will need to add the cloudformation:ListStacks permission by March 27, 2023, on any calling principles using the DescribeStacks API without a target. CloudFormation has identified principals associated with your account that do not have ListStacks permissions making DescribeStacks calls without a target. These users or roles need their policies updated to include cloudformation:ListStacks along with the existing cloudformation:DescribeStacks permissions:
