### PR TITLE
Remove ansible_lambda_role policy

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -32,15 +32,6 @@ Statement:
           - 'arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole'
           - 'arn:aws:iam::aws:policy/service-role/AWSServiceRoleForVPCTransitGateway'
 
-  # Legacy - We need to backport ansible-collections/community.aws/63 or
-  # wait until community.aws drops CI support for Ansible 2.9
-  - Sid: AllowPassRole
-    Effect: Allow
-    Action:
-      - iam:PassRole
-    Resource:
-      - 'arn:aws:iam::{{ aws_account_id }}:role/ansible_lambda_role'
-
   - Sid: AllowRegionalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:


### PR DESCRIPTION
We're no longer testing c.aws on Ansible 2.9 and policy/security-services.yaml is very close to the 6144 character limit.  We will also need to delete the role on the CI account.