### PR TITLE
Use correct imported timedelta for ECS

### DIFF
--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -146,7 +146,7 @@ class CloudFrontOriginAccessIdentity(DbTerminator):
 class Ecs(DbTerminator):
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=20)
+        return timedelta(minutes=20)
 
     @property
     def name(self):


### PR DESCRIPTION
timedelta is already imported directly into the module namespace. The datetime object is datetime.datetime.