### PR TITLE
Expand S3 permissions

### DIFF
--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -27,6 +27,7 @@ Statement:
       - s3:PutBucketAcl
       - s3:PutBucketLogging
       - s3:PutBucketNotification
+      - s3:PutBucketObjectLockConfiguration
       - s3:PutBucketOwnershipControls
       - s3:PutBucketPolicy
       - s3:PutBucketPublicAccessBlock


### PR DESCRIPTION
More permissions for https://github.com/ansible-collections/amazon.aws/pull/1372

missed because of the (previously) failing encryption tests.