### PR TITLE
Allow elasticache:ListTagsForResource

### DIFF
--- a/aws/policy/data-services.yaml
+++ b/aws/policy/data-services.yaml
@@ -49,6 +49,7 @@ Statement:
       - elasticache:DescribeCache*
       - elasticache:DescribeEngineDefaultParameters
       - elasticache:DescribeUpdateActions
+      - elasticache:ListTagsForResource
       - elasticache:ModifyCacheCluster
       - elasticache:ModifyCacheParameterGroup
       - elasticache:ModifyCacheSubnetGroup


### PR DESCRIPTION
The action is required to run the following task:

```
- name: List all the ElastiCache instances
  community.aws.elasticache_info:
  register: result_elasticache_info
```

and doesn't modify any existing resources.
