### PR TITLE
Route53: Add policies to get health_check status and failure_reason

### DIFF
--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -17,6 +17,8 @@ Statement:
       - route53:CreateHealthCheck
       - route53:DeleteHealthCheck
       - route53:GetHealthCheck
+      - route53:GetHealthCheckStatus
+      - route53:GetHealthCheckLastFailureReason
       - route53:ListHealthChecks
       - route53:UpdateHealthCheck
       - network-firewall:ListFirewallPolicies


### PR DESCRIPTION
Added missing permissions to get HealthCheck Status and HealthCheck LastFailureReason.

PR: https://github.com/ansible-collections/amazon.aws/pull/1419

Failing integration test tasks: https://github.com/ansible-collections/amazon.aws/pull/1419/files#diff-a01576dc4dd08820e5440bf3bf732a4fd26d4c79cd6a277b4d3a30ac1111d5ffR1728-R1752

API References
- [GetHealthCheckStatus](https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetHealthCheckStatus.html)
- [GetHealthCheckLastFailureReason](https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetHealthCheckLastFailureReason.html)

Boto3 APIs
- [get_health_check_status](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53/client/get_health_check_status.html)
- [get_health_check_last_failure_reason](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53/client/get_health_check_last_failure_reason.html)