### PR TITLE
Backup: Add policies to create/delete backup vault and perform tag operations

### DIFF
--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -54,7 +54,7 @@ Statement:
       - elasticfilesystem:UpdateFileSystem
       - backup:CreateBackupVault
       - backup:DeleteBackupVault
-      - backup:ListTags
+      - backup:List*
       - backup:TagResource
       - backup:UntagResource
     Resource: "*"

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -52,6 +52,11 @@ Statement:
       - elasticfilesystem:TagResource
       - elasticfilesystem:UntagResource
       - elasticfilesystem:UpdateFileSystem
+      - backup:CreateBackupVault
+      - backup:DeleteBackupVault
+      - backup:ListTags
+      - backup:TagResource
+      - backup:UntagResource
     Resource: "*"
 
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees


### PR DESCRIPTION
Added missing permissions to create/delete backup vault and perform tag operations on backup resources.

PR: https://github.com/ansible-collections/amazon.aws/pull/1427

Failing integration test: https://github.com/ansible-collections/amazon.aws/pull/1427/files#diff-6d74adc0f6f868eaaf22e8d48b7a1902fdb659ae3923ac6755aa1880921d0232

API References
- [CreateBackupVault](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_CreateBackupVault.html)
- [DeleteBackupVault](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_DeleteBackupVault.html)
- [ListTags](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_ListTags.html)
- [TagResource](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_TagResource.html)
- [UntagResource](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_UntagResource.html)