### PR TITLE
Add missing perms to create backup vault

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -50,6 +50,7 @@ Statement:
     Action:
       - kms:CancelKeyDeletion
       - kms:CreateKey
+      - kms:GenerateDataKey
       - kms:GenerateRandom
     Resource: "*"
     Condition:
@@ -135,6 +136,7 @@ Statement:
       - iam:RemoveRoleFromInstanceProfile
       - iam:UpdateSAMLProvider
       - iam:UpdateServerCertificate
+      - kms:Decrypt
       - logs:AssociateKmsKey
       - logs:CreateLogGroup
       - logs:DeleteLogGroup
@@ -157,6 +159,7 @@ Statement:
       # dms-vpc-role is hard coded into DMS...
       - 'arn:aws:iam::{{ aws_account_id }}:role/dms-vpc-role'
       - 'arn:aws:iam::{{ aws_account_id }}:role/rds_export_task'
+      - 'arn:aws:kms:{{ aws_region }}:{{ aws_account_id }}:key/ansible-test-*'
       - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:*'
       - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:ansible-test*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS'

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -57,6 +57,7 @@ Statement:
       - backup:List*
       - backup:TagResource
       - backup:UntagResource
+      - backup-storage:MountCapsule
     Resource: "*"
 
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees


### PR DESCRIPTION
There are a few extra permissions needed to create a backup vault. See: https://docs.aws.amazon.com/aws-backup/latest/devguide/access-control.html#backup-api-permissions-ref

Collection PR: https://github.com/ansible-collections/amazon.aws/pull/1427