### PR TITLE
Add support for S3 Access Points

### DIFF
--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -3,13 +3,16 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - s3:CreateAccessPoint*
       - s3:CreateBucket
+      - s3:DeleteAccessPoint*
       - s3:DeleteBucket
       - s3:DeleteBucketOwnershipControls
       - s3:DeleteObject
       - s3:DeleteObjects
       - s3:DeleteObjectTagging
       - s3:DeleteObjectVersionTagging
+      - s3:GetAccessPoint*
       - s3:GetBucket*
       - s3:GetEncryptionConfiguration
       - s3:GetLifecycleConfiguration
@@ -19,6 +22,7 @@ Statement:
       - s3:GetPublicAccessBlock
       - s3:HeadBucket
       - s3:HeadObject
+      - s3:ListAccessPoints*
       - s3:ListAllMyBuckets
       - s3:ListBucket
       - s3:ListBucketVersions

--- a/aws/terminator/storage_services.py
+++ b/aws/terminator/storage_services.py
@@ -77,6 +77,7 @@ class S3AccessPoint(Terminator):
     @staticmethod
     def create(credentials):
         account = get_account_id(credentials)
+
         def list_access_points(client):
             results = []
             access_points = client.list_access_points(AccountId=account).get("AccessPointList", [])
@@ -106,6 +107,7 @@ class S3AccessPointForObjectLambda(Terminator):
     @staticmethod
     def create(credentials):
         account = get_account_id(credentials)
+
         def list_access_points(client):
             results = []
             access_points = client.list_access_points_for_object_lambda(AccountId=account).get("ObjectLambdaAccessPointList", [])

--- a/aws/terminator/storage_services.py
+++ b/aws/terminator/storage_services.py
@@ -1,7 +1,7 @@
 import botocore
 import botocore.exceptions
 
-from . import Terminator
+from . import Terminator, get_account_id
 
 
 class S3Bucket(Terminator):
@@ -69,3 +69,57 @@ class SSMBucketObjects(Terminator):
 
     def terminate(self):
         self.client.delete_object(Bucket='ssm-encrypted-test-bucket', Key=self.name)
+
+
+class S3AccessPoint(Terminator):
+    @staticmethod
+    def create(credentials):
+        account = get_account_id(credentials)
+        def list_access_points(client):
+            results = []
+            access_points = client.list_access_points(AccountId=account).get("AccessPointList", [])
+            for ap in access_points:
+                results.append(client.get_access_point(AccountId=account, Name=ap['Name']))
+            return results
+        terminators = Terminator._create(credentials, S3AccessPoint, 's3control', list_access_points)
+        for terminator in terminators:
+            terminator._account_id = account
+        return terminators
+
+    @property
+    def name(self):
+        return self.instance['Name']
+
+    @property
+    def created_time(self):
+        return self.instance['CreationDate']
+
+    def terminate(self):
+        self.client.delete_access_point(AccountId=self._account_id, Name=self.name)
+
+
+class S3AccessPointForObjectLambda(Terminator):
+    @staticmethod
+    def create(credentials):
+        account = get_account_id(credentials)
+        def list_access_points(client):
+            results = []
+            access_points = client.list_access_points_for_object_lambda(AccountId=account).get("ObjectLambdaAccessPointList", [])
+            for ap in access_points:
+                results.append(client.get_access_point_for_object_lambda(AccountId=account, Name=ap['Name']))
+            return results
+        terminators = Terminator._create(credentials, S3AccessPointForObjectLambda, 's3control', list_access_points)
+        for terminator in terminators:
+            terminator._account_id = account
+        return terminators
+
+    @property
+    def name(self):
+        return self.instance['Name']
+
+    @property
+    def created_time(self):
+        return self.instance['CreationDate']
+
+    def terminate(self):
+        self.client.delete_access_point_for_object_lambda(AccountId=self._account_id, Name=self.name)

--- a/aws/terminator/storage_services.py
+++ b/aws/terminator/storage_services.py
@@ -72,6 +72,8 @@ class SSMBucketObjects(Terminator):
 
 
 class S3AccessPoint(Terminator):
+    _account_id = None
+
     @staticmethod
     def create(credentials):
         account = get_account_id(credentials)
@@ -99,6 +101,8 @@ class S3AccessPoint(Terminator):
 
 
 class S3AccessPointForObjectLambda(Terminator):
+    _account_id = None
+
     @staticmethod
     def create(credentials):
         account = get_account_id(credentials)


### PR DESCRIPTION
This adds policies and terminator classes for both S3 Access Points and S3 Access Points for Object Lambda.

Needed for https://github.com/ansible-collections/pravic/pull/10.