### PR TITLE
EC2 Snapshot : Add policies to modify and reset ec2 snapshot attributes

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -72,9 +72,11 @@ Statement:
       - ec2:ModifyImageAttribute
       - ec2:ModifyInstanceAttribute
       - ec2:ModifyLaunchTemplate
+      - ec2:ModifySnapshotAttribute
       - ec2:ModifyVolume
       - ec2:RegisterImage
       - ec2:ReplaceIamInstanceProfileAssociation
+      - ec2:ResetSnapshotAttribute
       - ec2:StopInstances
       - ec2:TerminateInstances
     Resource:


### PR DESCRIPTION
Added missing permissions to add policies to modify and reset ec2 snapshot attributes.

PR requiring permissions: https://github.com/ansible-collections/amazon.aws/pull/1464

Failing integration tests: https://github.com/ansible-collections/amazon.aws/pull/1464/files#diff-83ae4cc1be5e93fcb6401e881ed4a025c8445de502bdf44876ae1f852cb833f7R62-R70

API References:
[ModifySnapshotAttribute](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html)
[ResetSnapshotAttribute](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ResetSnapshotAttribute.html)