### PR TITLE
Add privilege to tag API gateway

### DIFF
--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -169,3 +169,4 @@ Statement:
       - apigateway:PUT
     Resource:
       - 'arn:aws:apigateway:{{ aws_region }}::/restapis*'
+      - 'arn:aws:apigateway:{{ aws_region }}::/tags/*'


### PR DESCRIPTION
The following exception error occurred 

```
User: arn:aws:sts::xxxxxxxx:assumed-role/ansible-core-ci-test-prod/prod=remote=xxxxx 
is not authorized to perform: apigateway:PUT on 
resource: arn:aws:apigateway:us-east-1::/tags/arn%3Aaws%3Aapigateway%3Aus-east-1%3A%3A%2Frestapis%2F*
because no identity-based policy allows the apigateway:PUT action
```
When testing the following pull request https://github.com/ansible-collections/community.aws/pull/1845
This pull request aims to solve that.