### PR TITLE
Add all backup service role policy arns to iam:AttachRolePolicy conditions

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -33,6 +33,9 @@ Statement:
           - 'arn:aws:iam::aws:policy/service-role/AWSServiceRoleForVPCTransitGateway'
           - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
           - 'arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup'
+          - 'arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores'
+          - 'arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup'
+          - 'arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore'
 
   - Sid: AllowRegionalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow


### PR DESCRIPTION
The new `backup_select_resources` role in cloud.aws_ops needs the ability create an IAM role and attach all backup service role policies. See failing integration test [here](https://github.com/redhat-cop/cloud.aws_ops/actions/runs/5762861921/job/15623464301?pr=81#step:9:2071). This PR adds the three added service role policy ARNs to the IAM:AttachRolePolicy action conditions.