### PR TITLE
EC2: add policy for modifying instance metadata options

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -70,6 +70,7 @@ Statement:
       - ec2:ImportKeyPair
       - ec2:ModifyImageAttribute
       - ec2:ModifyInstanceAttribute
+      - ec2:ModifyInstanceMetadataOptions
       - ec2:ModifyLaunchTemplate
       - ec2:ModifySnapshotAttribute
       - ec2:ModifyVolume


### PR DESCRIPTION
Added missing policies to modify ec2 instance metadata options.

PR needing permissions: https://github.com/ansible-collections/amazon.aws/pull/1918

API reference [ModifyInstanceMetadataOptions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceMetadataOptions.html)