### PR TITLE
add policy s3:DeleteObjectVersion

### DIFF
--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -11,6 +11,7 @@ Statement:
       - s3:DeleteObject
       - s3:DeleteObjects
       - s3:DeleteObjectTagging
+      - s3:DeleteObjectVersion
       - s3:DeleteObjectVersionTagging
       - s3:Get*
       - s3:HeadBucket


### PR DESCRIPTION
Trying to delete a non-empty bucket created with `versioning=true` required the following permission `s3:DeleteObjectVersion` as the module `amazon.aws.s3_bucket` will try to delete each object versioning before deleting the bucket.

Required for https://github.com/redhat-cop/cloud.terraform_ops/pull/1