### PR TITLE
ELB: add policy for adding listener certificates

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -154,11 +154,10 @@ Statement:
       - autoscaling:StartInstanceRefresh
       - autoscaling:TerminateInstanceInAutoScalingGroup
       - ec2:DeleteVolume
-      - elasticloadbalancing:AddTags
       - elasticloadbalancing:AddListenerCertificates
+      - elasticloadbalancing:AddTags
       - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
       - elasticloadbalancing:AttachLoadBalancerToSubnets
-      - elasticloadbalancing:RemoveTags
       - elasticloadbalancing:ConfigureHealthCheck
       - elasticloadbalancing:CreateAppCookieStickinessPolicy
       - elasticloadbalancing:CreateLBCookieStickinessPolicy
@@ -175,6 +174,7 @@ Statement:
       - elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer
       - elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer
       - elasticloadbalancing:ModifyLoadBalancerAttributes
+      - elasticloadbalancing:RemoveTags
       - elasticloadbalancing:RegisterInstancesWithLoadBalancer
       - elasticloadbalancing:RegisterTargets
       - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -155,6 +155,7 @@ Statement:
       - autoscaling:TerminateInstanceInAutoScalingGroup
       - ec2:DeleteVolume
       - elasticloadbalancing:AddTags
+      - elasticloadbalancing:AddListenerCertificates
       - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
       - elasticloadbalancing:AttachLoadBalancerToSubnets
       - elasticloadbalancing:RemoveTags

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -188,3 +188,4 @@ Statement:
       - 'arn:aws:elasticfilesystem:{{ aws_region }}:{{ aws_account_id }}:file-system/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:targetgroup/*'
       - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:loadbalancer/*'
+      - 'arn:aws:elasticloadbalancing:{{ aws_region }}:{{ aws_account_id }}:listener/*'


### PR DESCRIPTION
Added missing policies to add certificate to listener.

PR needing permissions: https://github.com/ansible-collections/amazon.aws/pull/1950

API reference [AddListenerCertificates](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_AddListenerCertificates.html)

Failing task: https://github.com/ansible-collections/amazon.aws/pull/1950/files#diff-401031aa90b02aecfcae9b6abf5e0ad28d5adb08698bee29b161c3c4c6e014f3R55-R72
