### PR TITLE
Added policies for CloudFront Cache Policies and CloudFront Origin Request Polcies

### DIFF
--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -25,9 +25,13 @@ Statement:
   - Sid: AllowResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - cloudfront:CreateCachePolicy
       - cloudfront:CreateInvalidation
+      - cloudfront:CreateOriginRequestPolicy
       - cloudfront:DeleteCloudFrontOriginAccessIdentity
+      - cloudfront:DeleteCachePolicy
       - cloudfront:DeleteDistribution
+      - cloudfront:DeleteOriginRequestPolicy
       - cloudfront:DeleteStreamingDistribution
       - cloudfront:TagResource
       - cloudfront:UntagResource
@@ -94,8 +98,10 @@ Statement:
       - lightsail:DeleteInstanceSnapshot
       - lightsail:GetInstanceSnapshots
     Resource:
+      - 'arn:aws:cloudfront::{{ aws_account_id }}:cache-policy/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:distribution/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:origin-access-identity/*'
+      - 'arn:aws:cloudfront::{{ aws_account_id }}:origin-request-policy/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:streaming-distribution/*'
       - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -143,6 +143,60 @@ class CloudFrontOriginAccessIdentity(DbTerminator):
         self.client.delete_cloud_front_origin_access_identity(Id=self.name, IfMatch=self.id)
 
 
+class CloudFrontCachePolicy(DbTerminator):
+    @staticmethod
+    def create(credentials):
+        def list_cloud_front_cache_policies(client):
+            identities = []
+            result = client.get_paginator('list_cache_policies').paginate(
+                # Only retrieve the custom policies
+                'Type': 'custom'
+            ).build_full_result()
+            for identity in result.get('CachePolicyList', {}).get('Items', []):
+                identities.append(client.get_cache_policy(Id=identity['Id']))
+            return identities
+
+        return Terminator._create(credentials, CloudFrontCachePolicy, 'cloudfront', list_cloud_front_cache_policies)
+
+    @property
+    def id(self):
+        return self.instance['ETag']
+
+    @property
+    def name(self):
+        return self.instance['CachePolicy']['Id']
+
+    def terminate(self):
+        self.client.delete_cache_policy(Id=self.name, IfMatch=self.id)
+
+
+class CloudFrontOriginRequestPolicy(DbTerminator):
+    @staticmethod
+    def create(credentials):
+        def list_cloud_front_origin_request_policies(client):
+            identities = []
+            result = client.get_paginator('list_origin_request_policies').paginate(
+                # Only retrieve the custom policies
+                'Type': 'custom'
+            ).build_full_result()
+            for identity in result.get('OriginRequestPolicyList', {}).get('Items', []):
+                identities.append(client.get_origin_request_policy(Id=identity['Id']))
+            return identities
+
+        return Terminator._create(credentials, CloudFrontOriginRequestPolicy, 'cloudfront', list_cloud_front_origin_request_policies)
+
+    @property
+    def id(self):
+        return self.instance['ETag']
+
+    @property
+    def name(self):
+        return self.instance['OriginRequestPolicy']['Id']
+
+    def terminate(self):
+        self.client.delete_origin_request_policy(Id=self.name, IfMatch=self.id)
+
+
 class Ecs(DbTerminator):
     @property
     def age_limit(self):


### PR DESCRIPTION
As part of [#2046](https://github.com/ansible-collections/community.aws/pull/2046), policies for CloudFront [Cache Policies](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront/client/create_cache_policy.html) and [Origin Request Policies](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront/client/create_origin_request_policy.html) are needed for the integration tests.  Therefore have filed this PR to add them.