### PR TITLE
Include t3a.micro in compute.yaml

### DIFF
--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -26,6 +26,7 @@ Statement:
           - t2.micro
           - t3.nano
           - t3.micro
+          - t3a.micro
           - m1.large  # lowest cost instance type with EBS optimization supported
 
   # Permit RunInstance to access any of the usual objects attached to an
@@ -101,6 +102,7 @@ Statement:
           - t2.micro
           - t3.nano
           - t3.micro
+          - t3a.micro
           - m1.large  # lowest cost instance type with EBS optimization supported
 
   # ASG and ELB don't like being region restricted.


### PR DESCRIPTION
This PR adds t3a.micro instance type to aws/policy/compute.yaml

Refer: https://issues.redhat.com/browse/ACA-1691