### PR TITLE
Add Ec2PlacementGroup terminator

### DIFF
--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -123,7 +123,7 @@ class Ec2PlacementGroup(DbTerminator):
 
     @property
     def age_limit(self):
-        return datetime.timedelta(minutes=30)
+        return datetime.timedelta(minutes=50)
 
     @property
     def name(self):

--- a/aws/terminator/compute.py
+++ b/aws/terminator/compute.py
@@ -116,6 +116,27 @@ class Ec2Image(Terminator):
         self.client.deregister_image(ImageId=self.id)
 
 
+class Ec2PlacementGroup(DbTerminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(credentials, Ec2PlacementGroup, 'ec2', lambda client: client.describe_placement_groups()['PlacementGroups'])
+
+    @property
+    def age_limit(self):
+        return datetime.timedelta(minutes=30)
+
+    @property
+    def name(self):
+        return self.instance['GroupName']
+
+    @property
+    def id(self):
+        return self.instance['GroupId']
+
+    def terminate(self):
+        self.client.delete_placement_group(GroupName=self.name)
+
+
 class Ec2Volume(Terminator):
     @staticmethod
     def create(credentials):


### PR DESCRIPTION
Permissions already exist for managing placement groups, but there was no terminator for it. I've set the age limit to 30 minutes, which is 10 minutes longer than the EC2 instance age. This should give the terminator time to clean up any lingering instances before attempting to delete the placement group.

Related ticket: https://issues.redhat.com/browse/ACA-1743