### PR TITLE
EC2: add policy for modifying EIP address attribute

### DIFF
--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -86,6 +86,7 @@ Statement:
       - ec2:DisassociateRouteTable
       - ec2:DisassociateSubnetCidrBlock
       - ec2:DisassociateVpcCidrBlock
+      - ec2:ModifyAddressAttribute
       - ec2:ModifyNetworkInterfaceAttribute
       - ec2:ModifySubnetAttribute
       - ec2:ModifyTransitGatewayPeeringAttachment


### PR DESCRIPTION
Added missing policies to modifying EIP address attribute.

PR needing permissions: https://github.com/ansible-collections/amazon.aws/pull/2292

API reference [ModifyAddressAttribute](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyAddressAttribute.html)

Failing test https://github.com/ansible-collections/amazon.aws/pull/2292/files#diff-f488fd5bb7aba3e76c16d8d5f54278c5ae14a110a436ab9042490c45bdd4b2e6R23-R28
