### PR TITLE
Use JSON logging for Lambda function

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -46,3 +46,4 @@ rules:
   trailing-spaces: enable
 ignore: |
   .tox/
+  .venv/

--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,15 +1,15 @@
 # note: The dependencies will be included in the Lambda package.
-boto3==1.25.5
-botocore==1.28.5
+boto3==1.40.19
+botocore==1.40.19
 certifi==2022.9.24
 charset-normalizer==2.1.1
 idna==3.4
 jmespath==1.0.1
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 requests==2.28.1
-s3transfer==0.6.0
-six==1.16.0
-urllib3==1.26.12
+s3transfer==0.13.1
+six==1.17.0
+urllib3==1.26.20
 # The PyYAML requirement is only used for the cleanup.py script,
 # so shouldn't be included here. Including it here will put it
 # into the venv which gets packaged up for the Lambda function,

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -111,6 +111,7 @@
           API_NAME: "{{ api_name }}"
         layers:
           - "{{ terminator_requirements_layer.layer.layer_version_arn }}"
+        log_format: JSON
       register: terminator_function
     - name: alias terminator functions
       tags: lambda

--- a/aws/terminator_lambda.py
+++ b/aws/terminator_lambda.py
@@ -1,16 +1,16 @@
 import logging
 import os
 
-from terminator import (
+logging.captureWarnings(True)  # noqa  # capture warnings as early as possible
+
+from terminator import (  # pylint: disable=wrong-import-position
     cleanup,
-    logger,
 )
 
 
 # noinspection PyUnusedLocal
 def lambda_handler(event, context):
     # pylint: disable=unused-argument
-    logger.setLevel(logging.INFO)
 
     arn = context.invoked_function_arn.split(':')
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 collections:
   - name: mattclay.aws
-    version: '2.0.0'
+    version: '4.1.0'
   - name: community.aws
     version: '3.3.0'
   - name: community.general


### PR DESCRIPTION
- Bump the `mattclay.aws` collection version to support JSON logging for Lambda functions.
- Update `boto3` and dependencies to support JSON logging for Lambda functions.
- Enable JSON logging for the Lambda function.
- Replace custom JSON formatted exception logging with Python standard logging.
- Configure Python warnings to go through the logging framework.
- Remove explicit log level configuration from the Lambda function.
- Exclude the `.venv/` directory from yamllint checks.