### PR TITLE
Delete task definitions after deregistering during cleanup

### DIFF
--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -183,6 +183,7 @@ Statement:
       - ecs:PutAccountSetting
       - ecs:RegisterTaskDefinition
       - ecs:DeregisterTaskDefinition
+      - ecs:DeleteTaskDefinitions
     Resource:
       - "*"
 

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -287,10 +287,12 @@ class Ecs(DbTerminator):
         for each in container_instances:
             self.client.deregister_container_instance(containerInstance=each['containerInstanceArn'], force=True)
 
-        # Deregister task definitions
+        # Deregister and delete task definitions
         task_definitions = _paginate_task_definition_results()
         for each in task_definitions:
             self.client.deregister_task_definition(taskDefinition=each)
+        for i in range(0, len(task_definitions), 10):
+            self.client.delete_task_definitions(taskDefinitions=task_definitions[i:i + 10])
 
         # Stop all the tasks
         tasks = _paginate_task_results()


### PR DESCRIPTION
## Summary
- Add `ecs:DeleteTaskDefinitions` permission to the paas policy
- Update `Ecs` terminator to call `delete_task_definitions` after deregistering, fully removing task definitions instead of leaving them in `INACTIVE` state
- Batches deletions in groups of 10 (API limit)

## Test plan
- [ ] Verify stale ECS task definitions are fully deleted during cleanup runs