### PR TITLE
Add Cognito user pool policy and terminator

### DIFF
--- a/aws/policy/application-security.yaml
+++ b/aws/policy/application-security.yaml
@@ -85,3 +85,36 @@ Statement:
       StringEquals:
         aws:RequestedRegion:
           - '{{ aws_region }}'
+
+  - Sid: CognitoServicesWhichDoNotIncurFees
+    Effect: Allow
+    Action:
+      - cognito-idp:CreateManagedLoginBranding
+      - cognito-idp:CreateUserClient
+      - cognito-idp:CreateUserPool
+      - cognito-idp:CreateUserPoolClient
+      - cognito-idp:CreateUserPoolDomain
+      - cognito-idp:DeleteManagedLoginBranding
+      - cognito-idp:DeleteUserPool
+      - cognito-idp:DeleteUserPoolClient
+      - cognito-idp:DeleteUserPoolDomain
+      - cognito-idp:DescribeManagedLoginBranding
+      - cognito-idp:DescribeManagedLoginBrandingByClient
+      - cognito-idp:DescribeUserPool
+      - cognito-idp:DescribeUserPoolClient
+      - cognito-idp:ListUserPoolClients
+      - cognito-idp:TagResource
+      - cognito-idp:UntagResource
+      - cognito-idp:UpdateManagedLoginBranding
+      - cognito-idp:UpdateUserPool
+      - cognito-idp:UpdateUserPoolClient
+    Resource:
+      - 'arn:aws:cognito-idp:{{ aws_region }}:{{ aws_account_id }}:userpool/*'
+
+  - Sid: CognitoServicesWhichDoNotIncurFeesGlobal
+    Effect: Allow
+    Action:
+      - cognito-idp:ListUserPools
+      - cognito-idp:DescribeUserPoolDomain
+    Resource:
+      - '*'

--- a/aws/policy/cognito.yaml
+++ b/aws/policy/cognito.yaml
@@ -1,0 +1,35 @@
+Version: '2012-10-17'
+Statement:
+
+  - Sid: CognitoServicesWhichDoNotIncurFees
+    Effect: Allow
+    Action:
+      - cognito-idp:CreateManagedLoginBranding
+      - cognito-idp:CreateUserClient
+      - cognito-idp:CreateUserPool
+      - cognito-idp:CreateUserPoolClient
+      - cognito-idp:CreateUserPoolDomain
+      - cognito-idp:DeleteManagedLoginBranding
+      - cognito-idp:DeleteUserPool
+      - cognito-idp:DeleteUserPoolClient
+      - cognito-idp:DeleteUserPoolDomain
+      - cognito-idp:DescribeManagedLoginBranding
+      - cognito-idp:DescribeManagedLoginBrandingByClient
+      - cognito-idp:DescribeUserPool
+      - cognito-idp:DescribeUserPoolClient
+      - cognito-idp:ListUserPoolClients
+      - cognito-idp:TagResource
+      - cognito-idp:UntagResource
+      - cognito-idp:UpdateManagedLoginBranding
+      - cognito-idp:UpdateUserPool
+      - cognito-idp:UpdateUserPoolClient
+    Resource:
+      - 'arn:aws:cognito-idp:{{ aws_region }}:{{ aws_account_id }}:userpool/*'
+
+  - Sid: CognitoServicesWhichDoNotIncurFeesGlobal
+    Effect: Allow
+    Action:
+      - cognito-idp:ListUserPools
+      - cognito-idp:DescribeUserPoolDomain
+    Resource:
+      - '*'

--- a/aws/terminator/application_security.py
+++ b/aws/terminator/application_security.py
@@ -273,6 +273,37 @@ class CloudfrontWafV2WebAcl(WafV2):
         self.client.delete_web_acl(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')
 
 
+class CognitoUserPool(Terminator):
+    @staticmethod
+    def create(credentials):
+        return Terminator._create(
+            credentials, CognitoUserPool, 'cognito-idp',
+            lambda client: client.get_paginator('list_user_pools').paginate(MaxResults=60).build_full_result()['UserPools']
+        )
+
+    @property
+    def id(self):
+        return self.instance['Id']
+
+    @property
+    def name(self):
+        return self.instance['Name']
+
+    @property
+    def created_time(self):
+        return self.instance['CreationDate']
+
+    def terminate(self):
+        # User pool domains must be deleted before the user pool can be deleted
+        user_pool = self.client.describe_user_pool(UserPoolId=self.id)['UserPool']
+        if user_pool.get('Domain'):
+            self.client.delete_user_pool_domain(
+                Domain=user_pool['Domain'],
+                UserPoolId=self.id,
+            )
+        self.client.delete_user_pool(UserPoolId=self.id)
+
+
 class InspectorAssessmentTemplate(DbTerminator):
     @staticmethod
     def create(credentials):


### PR DESCRIPTION
## Summary

- Add IAM policy for `cognito-idp` operations (user pools, clients, domains, and managed login branding)
- Add `CognitoUserPool` terminator class to clean up stale user pools left by integration tests
- The terminator handles deleting user pool domains before the pool itself (required by AWS), while clients and branding are automatically cleaned up with the pool

## Related

Supports ansible-collections/community.aws#2412, which adds new Cognito modules (`cognito_user_pool`, `cognito_user_pool_client`, `cognito_user_pool_domain`, `cognito_managed_login_branding`) with integration tests that create user pool resources.

## Test plan

- [ ] Verify terminator lambda discovers and cleans up Cognito user pools
- [ ] Verify user pool domains are deleted before the pool
- [ ] Verify policy grants sufficient permissions for both integration tests and teardown