### PR TITLE
Support non-us-east-1 regions for terminator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.retry
 *.pyc
 .tox
+.envrc
+aws/config.yml

--- a/aws/README.md
+++ b/aws/README.md
@@ -71,11 +71,15 @@ It is safest to use `cleanup.py` in an empty/dev account.
 
 To start using `cleanup.py` you will need to:
 * Use Python 3.13
+* Install `PyYAML` and `Jinja2` (these are not included in requirements.txt since the Lambda function does not need them):
+
+      pip install PyYAML Jinja2
+
 * Modify config.yml to use your own accounts. These can be the same account if you're just using `cleanup.py`.
   If you use two separate accounts, `lambda_account_id` is the account of the profile that will assume the IAM role in the `test_account_id`. The `test_account_id` is where the terminator class(es) will locate/remove resources.
 * Create a role called `ansible-core-ci-test-dev` that your AWS profile can assume. Give this role the permissions required by the terminator class you are testing.
 * Set the environment variable `AWS_PROFILE` with the profile you want to use.
-* Run `cleanup.py` using the class name as the target to locate the resources in us-east-1:
+* Run `cleanup.py` using the class name as the target to locate resources in the region configured in config.yml:
 
       python cleanup.py --stage dev --target Ec2Instance -v -c
       cleanup     : DEBUG    located Ec2Instance: count=2

--- a/aws/config.yml.example
+++ b/aws/config.yml.example
@@ -1,18 +1,21 @@
 # This is the account in which the lambda functions are run.
 # It must be different from the account which runs the integration tests.
-lambda_account_id: '461313337962'
+lambda_account_id: '123456789012'
 
 # This is the account which grants access to the integration test environment.
 # It must be different from the account which runs the integration tests.
 # It may be the same as the account which runs the lambda functions.
-access_account_id: '160936122096'
+access_account_id: '234567890123'
 
 # This is the account in which the integration tests are run.
 # It must be different from the account which runs the lambda functions.
-test_account_id: '966509639900'
+test_account_id: '345678901234'
 
 # The API name is used to tag and prefix aws resources.
 api_name: 'ansible-core-ci'
 
 # The AWS Region that tests will be run in
 aws_region: 'us-east-1'
+
+# The S3 bucket used for SSM connection plugin encrypted storage tests
+ssm_bucket_name: 'ssm-encrypted-test-bucket-{{ test_account_id }}'

--- a/aws/deploy-test-policy.yml
+++ b/aws/deploy-test-policy.yml
@@ -74,6 +74,14 @@
                   "arn:aws:iam::{{ lambda_account_id }}:root",
                   "arn:aws:iam::{{ access_account_id }}:root"
                 ]
+    - name: create persistent encrypted S3 bucket for SSM connection plugin tests
+      tags: [iam, s3]
+      amazon.aws.s3_bucket:
+        name: "{{ ssm_bucket_name }}"
+        state: present
+        encryption: AES256
+        region: "{{ aws_region }}"
+
     - name: create iam role for lambda functions created by integration tests
       tags: iam
       amazon.aws.iam_role:

--- a/aws/deploy-test-policy.yml
+++ b/aws/deploy-test-policy.yml
@@ -10,7 +10,9 @@
     - name: check config
       tags: always
       ansible.builtin.assert:
-        that: 'test_account_id != lambda_account_id'
+        that:
+          - 'test_account_id != lambda_account_id'
+          - 'ssm_bucket_name is defined'
     - name: check required variables
       tags: always
       ansible.builtin.fail: "msg='Environment variable {{ item | upper}} must be set.'"

--- a/aws/lookup_plugins/aws_region.py
+++ b/aws/lookup_plugins/aws_region.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ansible.plugins.lookup import LookupBase
+from ansible.plugins.lookup import LookupBase  # pylint: disable=import-error
 
 
 class LookupModule(LookupBase):

--- a/aws/policy/application-security.yaml
+++ b/aws/policy/application-security.yaml
@@ -21,21 +21,36 @@ Statement:
       - wafv2:DeleteFirewallManagerRuleGroups
       - wafv2:DisassociateFirewallManager
       - wafv2:UpdateIPSet
+      - wafv2:Describe*
+      - wafv2:TagResource
+      - wafv2:UntagResource
     Resource:
-      - 'arn:aws:wafv2:{{ aws_region }}:{{ aws_account_id }}:*'
+      - 'arn:aws:wafv2:{{ aws_region }}:{{ aws_account_id }}:regional/*'
+      - 'arn:aws:wafv2:us-east-1:{{ aws_account_id }}:global/*'
 
   - Sid: AllowRegionalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
       - inspector:List*
+      - inspector:Describe*
       - inspector:CreateResourceGroup
       - inspector:CreateAssessmentTarget
-      - inspector:Describe*
       - inspector:UpdateAssessmentTarget
       - inspector:DeleteAssessmentTarget
       - inspector:CreateAssessmentTemplate
       - inspector:DeleteAssessmentTemplate
       - inspector:SetTagsForResource
+    Resource: "*"
+    Condition:
+      StringEquals:
+        aws:RequestedRegion:
+          - '{{ aws_region }}'
+
+  - Sid: AllowWafUnrestrictedResourceActionsWhichIncurNoFees
+    Effect: Allow
+    Action:
+      - wafv2:Get*
+      - wafv2:List*
       - waf:CreateByteMatchSet
       - waf:CreateGeoMatchSet
       - waf:CreateIPSet
@@ -75,13 +90,4 @@ Statement:
       - waf:UpdateSqlInjectionMatchSet
       - waf:UpdateWebACL
       - waf:UpdateXssMatchSet
-      - wafv2:Describe*
-      - wafv2:Get*
-      - wafv2:List*
-      - wafv2:TagResource
-      - wafv2:UntagResource
     Resource: "*"
-    Condition:
-      StringEquals:
-        aws:RequestedRegion:
-          - '{{ aws_region }}'

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -13,7 +13,9 @@
     - name: check config
       tags: always
       ansible.builtin.assert:
-        that: 'test_account_id != lambda_account_id'
+        that:
+          - 'test_account_id != lambda_account_id'
+          - 'ssm_bucket_name is defined'
     - name: get aws account facts
       tags: always
       mattclay.aws.aws_account_facts:

--- a/aws/terminator.yml
+++ b/aws/terminator.yml
@@ -110,6 +110,8 @@
         environment:
           TEST_ACCOUNT_ID: "{{ test_account_id }}"
           API_NAME: "{{ api_name }}"
+          TEST_REGION: "{{ aws_region }}"
+          SSM_BUCKET_NAME: "{{ ssm_bucket_name }}"
         layers:
           - "{{ terminator_requirements_layer.layer.layer_version_arn }}"
         log_format: JSON

--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -15,7 +15,8 @@ import dateutil.tz
 
 logger = logging.getLogger('cleanup')
 
-AWS_REGION = 'us-east-1'
+AWS_REGION = os.environ.get('TEST_REGION', 'us-east-1')
+SSM_BUCKET_NAME = os.environ.get('SSM_BUCKET_NAME', 'ssm-encrypted-test-bucket')
 
 T = typing.TypeVar('T')
 
@@ -232,8 +233,9 @@ class Terminator(abc.ABC):
 
     @staticmethod
     def _create(session: boto3.Session, instance_type: typing.Type['Terminator'], client_name: str,
-                describe_lambda: typing.Callable[[botocore.client.BaseClient], typing.List[typing.Dict[str, typing.Any]]]) -> typing.List['Terminator']:
-        client = session.client(client_name, region_name=AWS_REGION)
+                describe_lambda: typing.Callable[[botocore.client.BaseClient], typing.List[typing.Dict[str, typing.Any]]],
+                region_name: typing.Optional[str] = None) -> typing.List['Terminator']:
+        client = session.client(client_name, region_name=region_name or AWS_REGION)
         instances = describe_lambda(client)
         terminators = [instance_type(client, instance) for instance in instances]
         logger.debug('located %s: count=%d', instance_type.__name__, len(terminators))

--- a/aws/terminator/__init__.py
+++ b/aws/terminator/__init__.py
@@ -28,11 +28,14 @@ def import_plugins() -> None:
         __import__(f'terminator.{import_name}')
 
 
-def cleanup(stage: str, check: bool, force: bool, api_name: str, test_account_id: str, targets: typing.Optional[typing.List[str]] = None) -> None:
+def cleanup(
+    stage: str, check: bool, force: bool, api_name: str, test_account_id: str, *,
+    targets: typing.Optional[typing.List[str]] = None
+) -> None:
     kvs.domain_name = re.sub(r'[^a-zA-Z0-9]+', '-', f'{api_name}-resources-{stage}')
     kvs.initialize()
 
-    cleanup_test_account(stage, check, force, api_name, test_account_id, targets)
+    cleanup_test_account(stage, check, force, api_name, test_account_id, targets=targets)
 
     if not targets or 'Database' in targets:
         cleanup_database(check, force)
@@ -62,7 +65,10 @@ def process_instance(instance: 'Terminator', check: bool, force: bool = False) -
     return status
 
 
-def cleanup_test_account(stage: str, check: bool, force: bool, api_name: str, test_account_id: str, targets: typing.Optional[typing.List[str]] = None) -> None:
+def cleanup_test_account(
+    stage: str, check: bool, force: bool, api_name: str, test_account_id: str, *,
+    targets: typing.Optional[typing.List[str]] = None
+) -> None:
     role = f'arn:aws:iam::{test_account_id}:role/{api_name}-test-{stage}'
     credentials = assume_session(role, 'cleanup')
 

--- a/aws/terminator/application_security.py
+++ b/aws/terminator/application_security.py
@@ -231,7 +231,11 @@ class RegionalWafV2IpSet(WafV2):
 class CloudfrontWafV2IpSet(WafV2):
     @staticmethod
     def create(credentials):
-        return DbTerminator._create(credentials, CloudfrontWafV2IpSet, 'wafv2', lambda client: client.list_ip_sets(Scope='CLOUDFRONT')['IPSets'], region_name='us-east-1')
+        return DbTerminator._create(
+            credentials, CloudfrontWafV2IpSet, 'wafv2',
+            lambda client: client.list_ip_sets(Scope='CLOUDFRONT')['IPSets'],
+            region_name='us-east-1'
+        )
 
     def terminate(self):
         self.client.delete_ip_set(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')
@@ -249,7 +253,11 @@ class RegionalWafV2RuleGroup(WafV2):
 class CloudfrontWafV2RuleGroup(WafV2):
     @staticmethod
     def create(credentials):
-        return DbTerminator._create(credentials, CloudfrontWafV2RuleGroup, 'wafv2', lambda client: client.list_rule_groups(Scope='CLOUDFRONT')['RuleGroups'], region_name='us-east-1')
+        return DbTerminator._create(
+            credentials, CloudfrontWafV2RuleGroup, 'wafv2',
+            lambda client: client.list_rule_groups(Scope='CLOUDFRONT')['RuleGroups'],
+            region_name='us-east-1'
+        )
 
     def terminate(self):
         self.client.delete_rule_group(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')
@@ -267,7 +275,11 @@ class RegionalWafV2WebAcl(WafV2):
 class CloudfrontWafV2WebAcl(WafV2):
     @staticmethod
     def create(credentials):
-        return DbTerminator._create(credentials, CloudfrontWafV2WebAcl, 'wafv2', lambda client: client.list_web_acls(Scope='CLOUDFRONT')['WebACLs'], region_name='us-east-1')
+        return DbTerminator._create(
+            credentials, CloudfrontWafV2WebAcl, 'wafv2',
+            lambda client: client.list_web_acls(Scope='CLOUDFRONT')['WebACLs'],
+            region_name='us-east-1'
+        )
 
     def terminate(self):
         self.client.delete_web_acl(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')

--- a/aws/terminator/application_security.py
+++ b/aws/terminator/application_security.py
@@ -231,7 +231,7 @@ class RegionalWafV2IpSet(WafV2):
 class CloudfrontWafV2IpSet(WafV2):
     @staticmethod
     def create(credentials):
-        return DbTerminator._create(credentials, CloudfrontWafV2IpSet, 'wafv2', lambda client: client.list_ip_sets(Scope='CLOUDFRONT')['IPSets'])
+        return DbTerminator._create(credentials, CloudfrontWafV2IpSet, 'wafv2', lambda client: client.list_ip_sets(Scope='CLOUDFRONT')['IPSets'], region_name='us-east-1')
 
     def terminate(self):
         self.client.delete_ip_set(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')
@@ -249,7 +249,7 @@ class RegionalWafV2RuleGroup(WafV2):
 class CloudfrontWafV2RuleGroup(WafV2):
     @staticmethod
     def create(credentials):
-        return DbTerminator._create(credentials, CloudfrontWafV2RuleGroup, 'wafv2', lambda client: client.list_rule_groups(Scope='CLOUDFRONT')['RuleGroups'])
+        return DbTerminator._create(credentials, CloudfrontWafV2RuleGroup, 'wafv2', lambda client: client.list_rule_groups(Scope='CLOUDFRONT')['RuleGroups'], region_name='us-east-1')
 
     def terminate(self):
         self.client.delete_rule_group(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')
@@ -267,7 +267,7 @@ class RegionalWafV2WebAcl(WafV2):
 class CloudfrontWafV2WebAcl(WafV2):
     @staticmethod
     def create(credentials):
-        return DbTerminator._create(credentials, CloudfrontWafV2WebAcl, 'wafv2', lambda client: client.list_web_acls(Scope='CLOUDFRONT')['WebACLs'])
+        return DbTerminator._create(credentials, CloudfrontWafV2WebAcl, 'wafv2', lambda client: client.list_web_acls(Scope='CLOUDFRONT')['WebACLs'], region_name='us-east-1')
 
     def terminate(self):
         self.client.delete_web_acl(Id=self.id, Name=self.name, LockToken=self.lock_token, Scope='CLOUDFRONT')

--- a/aws/terminator_lambda.py
+++ b/aws/terminator_lambda.py
@@ -18,7 +18,7 @@ def lambda_handler(event, context):
         arn.append('prod')  # hack to set the stage for testing in the lambda console
 
     if len(arn) != 8 or arn[5] != 'function' or arn[6] != context.function_name:
-        raise Exception(f'error: unexpected arn: {arn}')
+        raise ValueError(f'error: unexpected arn: {arn}')
 
     stage = arn[7]
 

--- a/aws/test_cleanup.py
+++ b/aws/test_cleanup.py
@@ -1,0 +1,48 @@
+"""Tests for cleanup.py config loading."""
+
+import os
+import tempfile
+
+# Import only the config loader — no boto3/terminator side effects needed
+from cleanup import load_config
+
+
+def test_load_config_renders_templates():
+    """Verify that Jinja2 templates in config are resolved against sibling values."""
+    config = load_config(os.path.join(os.path.dirname(__file__), 'config.yml'))
+
+    # ssm_bucket_name should have {{ test_account_id }} resolved
+    assert '{{' not in config['ssm_bucket_name'], \
+        f"Unresolved template in ssm_bucket_name: {config['ssm_bucket_name']}"
+    assert config['ssm_bucket_name'] == f"ssm-encrypted-test-bucket-{config['test_account_id']}"
+
+
+def test_load_config_preserves_plain_values():
+    """Verify that non-templated values pass through unchanged."""
+    config = load_config(os.path.join(os.path.dirname(__file__), 'config.yml'))
+
+    assert config['test_account_id'] == '208851973884'
+    assert config['api_name'] == 'ansible-core-ci'
+    assert config['aws_region'] == 'eu-west-1'
+
+
+def test_load_config_with_synthetic_file():
+    """Verify rendering works for an arbitrary config with cross-references."""
+    raw = (
+        "account: '12345'\n"
+        "bucket: 'my-bucket-{{ account }}'\n"
+    )
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+        f.write(raw)
+        f.flush()
+        config = load_config(f.name)
+
+    os.unlink(f.name)
+    assert config['bucket'] == 'my-bucket-12345'
+
+
+if __name__ == '__main__':
+    test_load_config_renders_templates()
+    test_load_config_preserves_plain_values()
+    test_load_config_with_synthetic_file()
+    print('All tests passed.')


### PR DESCRIPTION
## Summary

- Make terminator region configurable via `TEST_REGION` environment variable (default: `us-east-1`)
- Make SSM bucket name configurable via `SSM_BUCKET_NAME` environment variable (default: `ssm-encrypted-test-bucket`)
- Add `_create()` region override for global AWS services (CloudFront-scoped WAFv2)
- Split WAF Classic and WAFv2 read actions out of region-restricted IAM policy statements since they use global endpoints
- Add SSM encrypted test bucket creation step to `deploy-test-policy.yml`
- Move `config.yml` to `config.yml.example` and gitignore the real config (contains account IDs)
- Remove temporary hard-coded ARN for old Lambda account from test role trust policy

## Test plan

- [x] Verify terminator Lambda runs without WAF/WAFv2 access errors
- [x] Verify CloudFront-scoped WAFv2 terminator classes work from non-us-east-1 regions
- [x] Verify SSM bucket is created by `deploy-test-policy.yml`