### PR TITLE
feat: add cloudtrail:LookupEvents permission to application services policy

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -82,6 +82,7 @@ Statement:
       - SNS:List*
       - states:Describe*
       - states:List*
+      - cloudtrail:LookupEvents
     Resource: "*"
 
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
@@ -131,6 +132,7 @@ Statement:
       - states:DeleteStateMachine
       - states:TagResource
       - states:UntagResource
+      - cloudtrail:LookupEvents
     Resource:
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:document/*'
       - 'arn:aws:cloudformation:{{ aws_region }}:{{ aws_account_id }}:stack/*'
@@ -146,6 +148,7 @@ Statement:
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:parameter/*'
       - 'arn:aws:ssm:{{ aws_region }}::parameter/aws/service/*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
+      - 'arn:aws:cloudtrail:{{ aws_region }}:{{ aws_account_id }}:*'
 
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -82,7 +82,6 @@ Statement:
       - SNS:List*
       - states:Describe*
       - states:List*
-      - cloudtrail:LookupEvents
     Resource: "*"
 
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
@@ -132,7 +131,6 @@ Statement:
       - states:DeleteStateMachine
       - states:TagResource
       - states:UntagResource
-      - cloudtrail:LookupEvents
     Resource:
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:document/*'
       - 'arn:aws:cloudformation:{{ aws_region }}:{{ aws_account_id }}:stack/*'
@@ -148,7 +146,6 @@ Statement:
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:parameter/*'
       - 'arn:aws:ssm:{{ aws_region }}::parameter/aws/service/*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:cloudtrail:{{ aws_region }}:{{ aws_account_id }}:*'
 
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -66,6 +66,7 @@ Statement:
     Effect: Allow
     Action:
       - access-analyzer:ValidatePolicy
+      - cloudtrail:LookupEvents
       - iam:GetRole
       - iam:List*
       - iam:Tag*
@@ -91,7 +92,6 @@ Statement:
       - secretsmanager:Describe*
       - secretsmanager:GetRandomPassword
       - secretsmanager:List*
-      - cloudtrail:LookupEvents
     Resource: "*"
 
   - Sid: GlobalRestrictedResourceActionsWhichIncurFees
@@ -100,14 +100,13 @@ Statement:
       - iam:DeleteServerCertificate
       - iam:UploadServerCertificate
       - secretsmanager:CreateSecret
-      - secretsmanager:DeleteSecret
+      - secretsmanager:Delete*
       - secretsmanager:Get*
       - secretsmanager:RotateSecret
       - secretsmanager:TagResource
       - secretsmanager:UntagResource
       - secretsmanager:UpdateSecret
       - secretsmanager:PutResourcePolicy
-      - secretsmanager:DeleteResourcePolicy
       - secretsmanager:RemoveRegionsFromReplication
     Resource:
       - 'arn:aws:iam::{{ aws_account_id }}:server-certificate/ansible-test-*'

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -91,6 +91,7 @@ Statement:
       - secretsmanager:Describe*
       - secretsmanager:GetRandomPassword
       - secretsmanager:List*
+      - cloudtrail:LookupEvents
     Resource: "*"
 
   - Sid: GlobalRestrictedResourceActionsWhichIncurFees


### PR DESCRIPTION
Added required policies for running amazon.aws CloudTrail integration tests, PR [#2868](https://github.com/ansible-collections/amazon.aws/pull/2868)
