### PR TITLE
Add permissions for Regional VPC NAT Gateway Creation

### DIFF
--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -163,3 +163,13 @@ Statement:
     Resource:
       - 'arn:aws:apigateway:{{ aws_region }}::/restapis*'
       - 'arn:aws:apigateway:{{ aws_region }}::/tags/*'
+
+  - Sid: AllowNATGatewayServiceLinkedRole
+    Effect: Allow
+    Action:
+      - iam:CreateServiceLinkedRole
+    Resource:
+      - 'arn:aws:iam::*:role/aws-service-role/natgateway.amazonaws.com/*'
+    Condition:
+      StringEquals:
+        iam:AWSServiceName: natgateway.amazonaws.com


### PR DESCRIPTION
Updated networking policy to allow creation of regional VPC NAT gateways, supporting [PR 2989 in amazon.aws](https://github.com/ansible-collections/amazon.aws/pull/2989). I believe this  should address the errors I was encountering here: https://github.com/ansible-collections/amazon.aws/actions/runs/27252963478/job/80481206155?pr=2989. I used Claude Opus 4.6 to assist with understanding the policy formatting but modified the file myself.