### PR TITLE
Add SageMaker Image IAM permissions and terminator

### DIFF
--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -130,8 +130,8 @@ Statement:
       - cloudfront:List*
       - lambda:GetEventSourceMapping
       - lambda:List*
-      - sagemaker:List*
       - sagemaker:Describe*
+      - sagemaker:List*
     Resource:
       - "*"
 

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -89,6 +89,10 @@ Statement:
       - sagemaker:DeleteCodeRepository
       - sagemaker:DescribeCodeRepository
       - sagemaker:UpdateCodeRepository
+      - sagemaker:CreateImage
+      - sagemaker:DeleteImage
+      - sagemaker:DescribeImage
+      - sagemaker:UpdateImage
     Resource:
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent/*'
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
@@ -105,6 +109,7 @@ Statement:
       - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:layer:*'
       - 'arn:aws:sagemaker:{{ aws_region }}:{{ aws_account_id }}:code-repository/*'
+      - 'arn:aws:sagemaker:{{ aws_region }}:{{ aws_account_id }}:image/*'
 
   - Sid: AllowUnrestrictedResourceActionsWhichIncurFees
     Effect: Allow
@@ -125,6 +130,10 @@ Statement:
       - lambda:GetEventSourceMapping
       - lambda:List*
       - sagemaker:ListCodeRepositories
+      - sagemaker:ListImages
+      - sagemaker:AddTags
+      - sagemaker:DeleteTags
+      - sagemaker:ListTags
     Resource:
       - "*"
 

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -85,13 +85,14 @@ Statement:
       - lightsail:RebootInstance
       - lightsail:ReleaseStaticIp
       - lightsail:StopInstance
+      - sagemaker:AddTags
       - sagemaker:CreateCodeRepository
-      - sagemaker:DeleteCodeRepository
-      - sagemaker:DescribeCodeRepository
-      - sagemaker:UpdateCodeRepository
       - sagemaker:CreateImage
+      - sagemaker:DeleteCodeRepository
       - sagemaker:DeleteImage
-      - sagemaker:DescribeImage
+      - sagemaker:DeleteTags
+      - sagemaker:ListTags
+      - sagemaker:UpdateCodeRepository
       - sagemaker:UpdateImage
     Resource:
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent/*'
@@ -129,11 +130,8 @@ Statement:
       - cloudfront:List*
       - lambda:GetEventSourceMapping
       - lambda:List*
-      - sagemaker:ListCodeRepositories
-      - sagemaker:ListImages
-      - sagemaker:AddTags
-      - sagemaker:DeleteTags
-      - sagemaker:ListTags
+      - sagemaker:List*
+      - sagemaker:Describe*
     Resource:
       - "*"
 

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -14,6 +14,7 @@ Statement:
       ArnLike:
         iam:PolicyArn:
           - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
+          - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'
           - 'arn:aws:iam::aws:policy/AWSDenyAll'
           - 'arn:aws:iam::aws:policy/AmazonEKSServicePolicy'
           - 'arn:aws:iam::aws:policy/AmazonEKSClusterPolicy'

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+import botocore.exceptions
+
 from . import DbTerminator, Terminator
 
 
@@ -459,9 +461,13 @@ class SageMakerImage(Terminator):
     def name(self):
         return self.instance['ImageName']
 
+    @property
+    def ignore(self) -> bool:
+        return self.instance.get('ImageStatus') in ('CREATING', 'UPDATING', 'DELETING')
+
     def terminate(self):
-    try:
-        self.client.delete_image(ImageName=self.name)
-    except botocore.exceptions.ClientError as ex:
-        if not ex.response['Error']['Code'] == 'ResourceInUse':
-            raise
+        try:
+            self.client.delete_image(ImageName=self.name)
+        except botocore.exceptions.ClientError as ex:
+            if not ex.response['Error']['Code'] == 'ResourceInUse':
+                raise

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -435,3 +435,29 @@ class SageMakerCodeRepository(Terminator):
 
     def terminate(self):
         self.client.delete_code_repository(CodeRepositoryName=self.name)
+
+
+class SageMakerImage(Terminator):
+    @staticmethod
+    def create(credentials):
+        def _paginate_list_images(client):
+            images = client.get_paginator('list_images').paginate().build_full_result()['Images']
+
+            return [] if not images else images
+
+        return Terminator._create(credentials, SageMakerImage, 'sagemaker', _paginate_list_images)
+
+    @property
+    def created_time(self):
+        return self.instance.get('CreationTime')
+
+    @property
+    def id(self):
+        return self.instance['ImageArn']
+
+    @property
+    def name(self):
+        return self.instance['ImageName']
+
+    def terminate(self):
+        self.client.delete_image(ImageName=self.name)

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -460,4 +460,8 @@ class SageMakerImage(Terminator):
         return self.instance['ImageName']
 
     def terminate(self):
+    try:
         self.client.delete_image(ImageName=self.name)
+    except botocore.exceptions.ClientError as ex:
+        if not ex.response['Error']['Code'] == 'ResourceInUse':
+            raise


### PR DESCRIPTION
## Summary

Adds the IAM permissions and terminator needed for the `sagemaker_image` integration tests in [ansible-collections/amazon.ai](https://github.com/ansible-collections/amazon.ai) (see PR [#54](https://github.com/ansible-collections/amazon.ai/pull/54)).

## Changes

### `aws/policy/paas.yaml`

- Added `sagemaker:CreateImage`, `sagemaker:DescribeImage`, `sagemaker:UpdateImage`, `sagemaker:DeleteImage` to `AllowResourceRestrictedActionsWhichIncurNoFees` with resource `arn:aws:sagemaker:...:image/*`
- Added `sagemaker:ListImages`, `sagemaker:AddTags`, `sagemaker:DeleteTags`, `sagemaker:ListTags` to `AllowUnrestrictedResourceActionsWhichIncurNoFees`

### `aws/policy/security-services.yaml`

- Added `arn:aws:iam::aws:policy/AmazonSageMakerFullAccess` to the allowed `iam:PolicyArn` condition for `iam:AttachRolePolicy` so the test IAM role can be set up correctly

### `aws/terminator/paas.py`

- Added `SageMakerImage` terminator class to clean up leaked SageMaker Image resources after test runs, following the same pattern as the existing `SageMakerCodeRepository` terminator