### PR TITLE
Redistribute ECR policies and clean up policy files

### DIFF
--- a/aws/policy/application-security.yaml
+++ b/aws/policy/application-security.yaml
@@ -5,37 +5,37 @@ Statement:
     Effect: Allow
     Action:
       - wafv2:AssociateWebACL
-      - wafv2:DeleteRuleGroup
-      - wafv2:CreateRuleGroup
-      - wafv2:PutFirewallManagerRuleGroups
-      - wafv2:DeleteWebACL
-      - wafv2:CreateWebACL
-      - wafv2:CreateIPSet
-      - wafv2:DeleteIPSet
       - wafv2:CheckCapacity
-      - wafv2:DeleteLoggingConfiguration
-      - wafv2:PutLoggingConfiguration
-      - wafv2:DisassociateWebACL
-      - wafv2:UpdateWebACL
-      - wafv2:UpdateRuleGroup
+      - wafv2:CreateIPSet
+      - wafv2:CreateRuleGroup
+      - wafv2:CreateWebACL
       - wafv2:DeleteFirewallManagerRuleGroups
+      - wafv2:DeleteIPSet
+      - wafv2:DeleteLoggingConfiguration
+      - wafv2:DeleteRuleGroup
+      - wafv2:DeleteWebACL
       - wafv2:DisassociateFirewallManager
+      - wafv2:DisassociateWebACL
+      - wafv2:PutFirewallManagerRuleGroups
+      - wafv2:PutLoggingConfiguration
       - wafv2:UpdateIPSet
+      - wafv2:UpdateRuleGroup
+      - wafv2:UpdateWebACL
     Resource:
       - 'arn:aws:wafv2:{{ aws_region }}:{{ aws_account_id }}:*'
 
   - Sid: AllowRegionalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - inspector:List*
-      - inspector:CreateResourceGroup
       - inspector:CreateAssessmentTarget
-      - inspector:Describe*
-      - inspector:UpdateAssessmentTarget
-      - inspector:DeleteAssessmentTarget
       - inspector:CreateAssessmentTemplate
+      - inspector:CreateResourceGroup
+      - inspector:DeleteAssessmentTarget
       - inspector:DeleteAssessmentTemplate
+      - inspector:Describe*
+      - inspector:List*
       - inspector:SetTagsForResource
+      - inspector:UpdateAssessmentTarget
       - waf:CreateByteMatchSet
       - waf:CreateGeoMatchSet
       - waf:CreateIPSet

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -33,7 +33,6 @@ Statement:
       - events:PutRule
       - events:PutTargets
       - events:RemoveTargets
-      - glue:Get*
       - kinesis:Describe*
       - kinesis:List*
       - mq:Describe*
@@ -87,8 +86,6 @@ Statement:
   - Sid: AllowGlobalResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - ssm:CreateDocument
-      - ssm:DeleteDocument
       - cloudformation:CreateChangeSet
       - cloudformation:CreateStack
       - cloudformation:DeleteChangeSet
@@ -120,19 +117,20 @@ Statement:
       - mq:CreateTags
       - SNS:CreateTopic
       - SNS:DeleteTopic
-      - SNS:TagResource
       - SNS:SetSubscriptionAttributes
       - SNS:SetTopicAttributes
       - SNS:Subscribe
+      - SNS:TagResource
       - SNS:Unsubscribe
       - SNS:UntagResource
+      - ssm:CreateDocument
+      - ssm:DeleteDocument
       - ssm:DeleteParameter
       - ssm:PutParameter
       - states:DeleteStateMachine
       - states:TagResource
       - states:UntagResource
     Resource:
-      - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:document/*'
       - 'arn:aws:cloudformation:{{ aws_region }}:{{ aws_account_id }}:stack/*'
       - 'arn:aws:cloudwatch:{{ aws_region }}:{{ aws_account_id }}:alarm:*'
       - 'arn:aws:codebuild:{{ aws_region }}:{{ aws_account_id }}:*'
@@ -143,6 +141,7 @@ Statement:
       - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
       - 'arn:aws:mq:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:sns:{{ aws_region }}:{{ aws_account_id }}:*'
+      - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:document/*'
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:parameter/*'
       - 'arn:aws:ssm:{{ aws_region }}::parameter/aws/service/*'
       - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
@@ -165,12 +164,12 @@ Statement:
       - states:StopExecution
       - states:UpdateStateMachine
     Resource:
-      - 'arn:aws:sns:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:mq:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
       - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:crawler/*'
       - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:job/*'
+      - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
+      - 'arn:aws:mq:{{ aws_region }}:{{ aws_account_id }}:*'
+      - 'arn:aws:sns:{{ aws_region }}:{{ aws_account_id }}:*'
+      - 'arn:aws:states:{{ aws_region }}:{{ aws_account_id }}:*'
 
   # Used to test some of the cross-account features
   - Sid: PermitReadOnlyThirdParty

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -9,8 +9,8 @@ Statement:
       - autoscaling:AttachInstances
       - autoscaling:CreateAutoScalingGroup
       - autoscaling:CreateLaunchConfiguration
-      - autoscaling:UpdateAutoScalingGroup
       - autoscaling:DetachInstances
+      - autoscaling:UpdateAutoScalingGroup
       - ec2:RunInstances
       - ec2:StartInstances
     Resource:
@@ -114,13 +114,13 @@ Statement:
       - autoscaling:ResumeProcesses
       - autoscaling:SuspendProcesses
       - ec2:Describe*
-      - elasticloadbalancing:DeleteRule
       - elasticloadbalancing:DeleteListener
-      - elasticloadbalancing:Describe*
+      - elasticloadbalancing:DeleteRule
       - elasticloadbalancing:DeregisterTargets
+      - elasticloadbalancing:Describe*
       - elasticloadbalancing:ModifyListener
-      - elasticloadbalancing:ModifyTargetGroupAttributes
       - elasticloadbalancing:ModifyRule
+      - elasticloadbalancing:ModifyTargetGroupAttributes
       - elasticloadbalancing:SetIpAddressType
       - elasticloadbalancing:SetRulePriorities
     Resource:
@@ -146,15 +146,15 @@ Statement:
       - autoscaling:CompleteLifecycleAction
       - autoscaling:CreateOrUpdateTags
       - autoscaling:Delete*
-      - autoscaling:DetachLoadBalancers
       - autoscaling:DetachLoadBalancerTargetGroups
+      - autoscaling:DetachLoadBalancers
       - autoscaling:DisableMetricsCollection
+      - autoscaling:PutLifecycleHook
       - autoscaling:PutScalingPolicy
       - autoscaling:PutScheduledUpdateGroupAction
-      - autoscaling:PutLifecycleHook
-      - autoscaling:StartInstanceRefresh
       - autoscaling:SetInstanceHealth
       - autoscaling:SetInstanceProtection
+      - autoscaling:StartInstanceRefresh
       - autoscaling:TerminateInstanceInAutoScalingGroup
       - ec2:DeleteVolume
       - elasticloadbalancing:AddListenerCertificates
@@ -172,9 +172,9 @@ Statement:
       - elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer
       - elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer
       - elasticloadbalancing:ModifyLoadBalancerAttributes
-      - elasticloadbalancing:RemoveTags
       - elasticloadbalancing:RegisterInstancesWithLoadBalancer
       - elasticloadbalancing:RegisterTargets
+      - elasticloadbalancing:RemoveTags
       - elasticloadbalancing:SetLoadBalancer*
       - elasticloadbalancing:SetSecurityGroups
       - elasticloadbalancing:SetWebACL

--- a/aws/policy/data-services.yaml
+++ b/aws/policy/data-services.yaml
@@ -6,17 +6,17 @@ Statement:
       - dms:CreateEndpoint
       - dms:Describe*
       - dms:List*
-      - dynamodb:Get*
       - dynamodb:Describe*
+      - dynamodb:Get*
       - dynamodb:List*
       - dynamodb:Query
       - dynamodb:Scan
       - elasticache:Describe*
       - elasticache:List*
       - glacier:List*
-      - glue:Get*
       - glue:CreateConnection
       - glue:DeleteConnection
+      - glue:Get*
       - glue:UpdateConnection
       - rds:Describe*
       - rds:List*
@@ -51,10 +51,52 @@ Statement:
       - elasticache:ModifyCacheParameterGroup
       - elasticache:ModifyCacheSubnetGroup
       - elasticache:RemoveTagsFromResource
+      - glacier:AddTagsToVault
       - glacier:CreateVault
       - glacier:DeleteVault
-      - glacier:AddTagsToVault
       - glacier:RemoveTagsFromVault
+      - rds:AddTagsToResource
+      - rds:CancelExportTask
+      - rds:CopyDBClusterSnapshot
+      - rds:CopyDBSnapshot
+      - rds:CreateDBClusterParameterGroup
+      - rds:CreateDBClusterSnapshot
+      - rds:CreateDBInstance
+      - rds:CreateDBInstanceReadReplica
+      - rds:CreateDBParameterGroup
+      - rds:CreateDBSnapshot
+      - rds:CreateDBSubnetGroup
+      - rds:CreateOptionGroup
+      - rds:DeleteDBCluster
+      - rds:DeleteDBClusterParameterGroup
+      - rds:DeleteDBClusterSnapshot
+      - rds:DeleteDBInstance
+      - rds:DeleteDBParameterGroup
+      - rds:DeleteDBSnapshot
+      - rds:DeleteDBSubnetGroup
+      - rds:DeleteOptionGroup
+      - rds:ModifyDBCluster
+      - rds:ModifyDBClusterParameterGroup
+      - rds:ModifyDBInstance
+      - rds:ModifyDBParameterGroup
+      - rds:ModifyDBSubnetGroup
+      - rds:ModifyOptionGroup
+      - rds:PromoteReadReplica
+      - rds:PromoteReadReplicaDBCluster
+      - rds:RebootDBCluster
+      - rds:RebootDBInstance
+      - rds:RemoveTagsFromResource
+      - rds:RestoreDBClusterFromS3
+      - rds:RestoreDBClusterFromSnapshot
+      - rds:RestoreDBClusterToPointInTime
+      - rds:RestoreDBInstanceFromDBSnapshot
+      - rds:RestoreDBInstanceFromS3
+      - rds:RestoreDBInstanceToPointInTime
+      - rds:StartDBCluster
+      - rds:StartDBInstance
+      - rds:StartExportTask
+      - rds:StopDBCluster
+      - rds:StopDBInstance
       - redshift:CreateClusterSubnetGroup
       - redshift:CreateTags
       - redshift:DeleteCluster
@@ -63,81 +105,38 @@ Statement:
       - redshift:ModifyCluster
       - redshift:ModifyClusterSubnetGroup
       - redshift:RebootCluster
-      - rds:AddTagsToResource
-      - rds:CreateDBParameterGroup
-      - rds:CreateDBClusterParameterGroup
-      - rds:CreateDBSubnetGroup
-      - rds:DeleteDBCluster
-      - rds:DeleteDBParameterGroup
-      - rds:DeleteDBClusterParameterGroup
-      - rds:DeleteDBSubnetGroup
-      - rds:RestoreDBInstanceToPointInTime
-      - rds:RestoreDBInstanceFromDBSnapshot
-      - rds:RestoreDBInstanceFromS3
-      - rds:CreateDBInstanceReadReplica
-      - rds:CreateDBInstance
-      - rds:ModifyDBInstance
-      - rds:DeleteDBInstance
-      - rds:StopDBCluster
-      - rds:StopDBInstance
-      - rds:StartDBCluster
-      - rds:StartDBInstance
-      - rds:PromoteReadReplica
-      - rds:RebootDBCluster
-      - rds:RebootDBInstance
-      - rds:ModifyDBCluster
-      - rds:ModifyDBParameterGroup
-      - rds:ModifyDBClusterParameterGroup
-      - rds:ModifyDBSubnetGroup
-      - rds:RemoveTagsFromResource
-      - rds:CreateOptionGroup
-      - rds:ModifyOptionGroup
-      - rds:DeleteOptionGroup
-      - rds:CreateDBClusterSnapshot
-      - rds:DeleteDBClusterSnapshot
-      - rds:CreateDBSnapshot
-      - rds:DeleteDBSnapshot
-      - rds:CopyDBSnapshot
-      - rds:StartExportTask
-      - rds:CancelExportTask
-      - rds:RestoreDBClusterToPointInTime
-      - rds:RestoreDBClusterFromSnapshot
-      - rds:RestoreDBClusterFromS3
-      - rds:PromoteReadReplicaDBCluster
-      - rds:CopyDBClusterSnapshot
     Resource:
       - 'arn:aws:dms:{{ aws_region }}:{{ aws_account_id }}:endpoint:*'
       - 'arn:aws:dms:{{ aws_region }}:{{ aws_account_id }}:subgrp:*'
       - 'arn:aws:dynamodb:{{ aws_region }}:{{ aws_account_id }}:table/*'
       - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
-      - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:subnetgroup:*'
       - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:parametergroup:*'
       - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:securitygroup:*'
+      - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:subnetgroup:*'
       - 'arn:aws:glacier:{{ aws_region }}:{{ aws_account_id }}:vaults/*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster-pg:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster-snapshot:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:db:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:og:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:pg:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:snapshot:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:subgrp:*'
       - 'arn:aws:redshift:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
       - 'arn:aws:redshift:{{ aws_region }}:{{ aws_account_id }}:subnetgroup:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:subgrp:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:db:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:pg:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster-pg:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:og:*'
-      - 'arn:aws:dms:{{ aws_region }}:{{ aws_account_id }}:endpoint:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:snapshot:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster-snapshot:*'
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
     Action:
-      - rds:CreateDBCluster
       - elasticache:CreateCacheCluster
+      - rds:CreateDBCluster
       - redshift:CreateCluster
     Resource:
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
-      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:subgrp:*'
       - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
-      - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:subnetgroup:*'
       - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:parametergroup:*'
       - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:securitygroup:*'
+      - 'arn:aws:elasticache:{{ aws_region }}:{{ aws_account_id }}:subnetgroup:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
+      - 'arn:aws:rds:{{ aws_region }}:{{ aws_account_id }}:subgrp:*'
       - 'arn:aws:redshift:{{ aws_region }}:{{ aws_account_id }}:cluster:*'
   # This allows AWS Services to autmatically create their Default Service Linked Roles
   # These have fixed policies and can only be assumed by the service itself.
@@ -163,8 +162,8 @@ Statement:
       - kafka:Describe*
       - kafka:Get*
       - kafka:List*
-      - kafka:TagResource
       - kafka:RebootBroker
+      - kafka:TagResource
       - kafka:UntagResource
       - kafka:UpdateBrokerCount
       - kafka:UpdateBrokerStorage

--- a/aws/policy/networking.yaml
+++ b/aws/policy/networking.yaml
@@ -3,25 +3,25 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - network-firewall:Describe*
+      - network-firewall:List*
       - route53:ActivateKeySigningKey
-      - route53:ChangeResourceRecordSets
-      - route53:List*
-      - route53:CreateHostedZone
-      - route53:CreateKeySigningKey
-      - route53:Get*
-      - route53:DeleteHostedZone
-      - route53:UpdateHostedZoneComment
       - route53:AssociateVPCWithHostedZone
+      - route53:ChangeResourceRecordSets
       - route53:ChangeTagsForResource
       - route53:CreateHealthCheck
+      - route53:CreateHostedZone
+      - route53:CreateKeySigningKey
       - route53:DeactivateKeySigningKey
       - route53:DeleteHealthCheck
+      - route53:DeleteHostedZone
       - route53:DeleteKeySigningKey
       - route53:DisableHostedZoneDNSSEC
       - route53:EnableHostedZoneDNSSEC
+      - route53:Get*
+      - route53:List*
       - route53:UpdateHealthCheck
-      - network-firewall:List*
-      - network-firewall:Describe*
+      - route53:UpdateHostedZoneComment
     Resource: "*"
 
   - Sid: AllowRegionalUnrestrictedResourceActionsWhichIncurNoFees
@@ -31,9 +31,8 @@ Statement:
       - ec2:AcceptTransitGatewayVpcAttachment
       - ec2:AcceptVpcPeeringConnection
       - ec2:AllocateAddress
-      - ec2:AssociateAddress
       - ec2:AssignPrivateIpAddresses
-      - ec2:UnassignPrivateIpAddresses
+      - ec2:AssociateAddress
       - ec2:AssociateDhcpOptions
       - ec2:AssociateRouteTable
       - ec2:AssociateSubnetCidrBlock
@@ -48,9 +47,6 @@ Statement:
       - ec2:CreateEgressOnlyInternetGateway
       - ec2:CreateInternetGateway
       - ec2:CreateNatGateway
-      - ec2:CreateTransitGateway
-      - ec2:CreateTransitGatewayPeeringAttachment
-      - ec2:CreateTransitGatewayVpcAttachment
       - ec2:CreateNetworkAcl
       - ec2:CreateNetworkAclEntry
       - ec2:CreateNetworkInterface
@@ -59,6 +55,9 @@ Statement:
       - ec2:CreateRouteTable
       - ec2:CreateSecurityGroup
       - ec2:CreateSubnet
+      - ec2:CreateTransitGateway
+      - ec2:CreateTransitGatewayPeeringAttachment
+      - ec2:CreateTransitGatewayVpcAttachment
       - ec2:CreateVpc
       - ec2:CreateVpcEndpoint
       - ec2:CreateVpcPeeringConnection
@@ -77,14 +76,14 @@ Statement:
       - ec2:DeleteRouteTable
       - ec2:DeleteSecurityGroup
       - ec2:DeleteSubnet
+      - ec2:DeleteTransitGateway
+      - ec2:DeleteTransitGatewayPeeringAttachment
+      - ec2:DeleteTransitGatewayVpcAttachment
       - ec2:DeleteVpc
       - ec2:DeleteVpcEndpoints
       - ec2:DeleteVpcPeeringConnection
       - ec2:DeleteVpnConnection
       - ec2:DeleteVpnGateway
-      - ec2:DeleteTransitGateway
-      - ec2:DeleteTransitGatewayPeeringAttachment
-      - ec2:DeleteTransitGatewayVpcAttachment
       - ec2:DetachInternetGateway
       - ec2:DetachNetworkInterface
       - ec2:DetachVpnGateway
@@ -108,6 +107,7 @@ Statement:
       # - ec2:ReplaceRouteTableAssociation
       - ec2:RevokeSecurityGroupEgress
       - ec2:RevokeSecurityGroupIngress
+      - ec2:UnassignPrivateIpAddresses
       - ec2:UpdateSecurityGroupRuleDescriptionsEgress
       - ec2:UpdateSecurityGroupRuleDescriptionsIngress
     Resource:

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -10,13 +10,9 @@ Statement:
       - eks:CreateNodegroup
       - eks:UpdateNodegroupConfig
       - lambda:InvokeFunction
+      - lightsail:CreateInstanceSnapshot
       - lightsail:CreateInstances
       - lightsail:StartInstance
-      - lightsail:CreateInstanceSnapshot
-      - ecr:CompleteLayerUpload
-      - ecr:InitiateLayerUpload
-      - ecr:PutImage
-      - ecr:UploadLayerPart
     Resource:
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
       - 'arn:aws:bedrock:{{ aws_region }}::foundation-model/*'
@@ -24,7 +20,6 @@ Statement:
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:nodegroup/*/*/*'
       - 'arn:aws:lambda:{{ aws_region }}:{{ aws_account_id }}:function:*'
       - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
-      - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
 
   - Sid: AllowResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
@@ -50,16 +45,6 @@ Statement:
       - cloudfront:UpdateCloudFrontOriginAccessIdentity
       - cloudfront:UpdateDistribution
       - cloudfront:UpdateOriginRequestPolicy
-      - ecr:DeleteLifecyclePolicy
-      - ecr:DeleteRepository
-      - ecr:DeleteRepositoryPolicy
-      - ecr:GetLifecyclePolicy
-      - ecr:GetRepositoryPolicy
-      - ecr:PutImageScanningConfiguration
-      - ecr:PutLifecyclePolicy
-      - ecr:SetRepositoryPolicy
-      - ecr:BatchDeleteImages
-      - ecr:BatchCheckLayerAvailability
       - eks:DeleteCluster
       - eks:Describe*
       - eks:List*
@@ -97,19 +82,13 @@ Statement:
       - lightsail:AllocateStaticIp
       - lightsail:CreateKeyPair
       - lightsail:DeleteInstance
-      - lightsail:DeleteKeyPair
-      - lightsail:GetInstance
-      - lightsail:GetInstances
-      - lightsail:GetKeyPairs
-      - lightsail:GetStaticIp
-      - lightsail:GetStaticIps
-      - lightsail:RebootInstance
-      - lightsail:StopInstance
-      - lightsail:ReleaseStaticIp
-      - lightsail:PutInstancePublicPorts
-      - lightsail:GetInstanceSnapshot
       - lightsail:DeleteInstanceSnapshot
-      - lightsail:GetInstanceSnapshots
+      - lightsail:DeleteKeyPair
+      - lightsail:Get*
+      - lightsail:PutInstancePublicPorts
+      - lightsail:RebootInstance
+      - lightsail:ReleaseStaticIp
+      - lightsail:StopInstance
       - sagemaker:CreateCodeRepository
       - sagemaker:DeleteCodeRepository
       - sagemaker:DescribeCodeRepository
@@ -122,7 +101,6 @@ Statement:
       - 'arn:aws:cloudfront::{{ aws_account_id }}:origin-access-identity/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:origin-request-policy/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:streaming-distribution/*'
-      - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:cluster/*'
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:fargateprofile/*/*/*'
       - 'arn:aws:eks:{{ aws_region }}:{{ aws_account_id }}:nodegroup/*/*/*'
@@ -149,11 +127,6 @@ Statement:
       - cloudfront:CreateCloudFrontOriginAccessIdentity
       - cloudfront:Get*
       - cloudfront:List*
-      - ecr:GetAuthorizationToken
-      - ecr:CreateRepository
-      - ecr:Describe*
-      - ecr:List*
-      - ecr:PutImageTagMutability
       - lambda:GetEventSourceMapping
       - lambda:List*
       - sagemaker:ListCodeRepositories

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -26,8 +26,6 @@ Statement:
       - bedrock:CreateAgent*
       - bedrock:DeleteAgent*
       - bedrock:DisableAgentActionGroup
-      - bedrock:GetAgent*
-      - bedrock:ListAgent*
       - bedrock:PrepareAgent
       - bedrock:UpdateAgent*
       - cloudfront:CreateCachePolicy
@@ -119,8 +117,8 @@ Statement:
   - Sid: AllowUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - bedrock:GetFoundationModel
-      - bedrock:ListFoundationModels
+      - bedrock:Get*
+      - bedrock:List*
       - cloudfront:CreateCloudFrontOriginAccessIdentity
       - cloudfront:Get*
       - cloudfront:List*

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -4,8 +4,7 @@ Statement:
   - Sid: AllowResourceRestrictedActionsWhichIncurFees
     Effect: Allow
     Action:
-      - bedrock:InvokeAgent
-      - bedrock:InvokeModel
+      - bedrock:Invoke*
       - eks:CreateCluster
       - eks:CreateNodegroup
       - eks:UpdateNodegroupConfig
@@ -34,8 +33,8 @@ Statement:
       - cloudfront:CreateCachePolicy
       - cloudfront:CreateInvalidation
       - cloudfront:CreateOriginRequestPolicy
-      - cloudfront:DeleteCloudFrontOriginAccessIdentity
       - cloudfront:DeleteCachePolicy
+      - cloudfront:DeleteCloudFrontOriginAccessIdentity
       - cloudfront:DeleteDistribution
       - cloudfront:DeleteOriginRequestPolicy
       - cloudfront:DeleteStreamingDistribution
@@ -45,16 +44,15 @@ Statement:
       - cloudfront:UpdateCloudFrontOriginAccessIdentity
       - cloudfront:UpdateDistribution
       - cloudfront:UpdateOriginRequestPolicy
+      - eks:CreateFargateProfile
       - eks:DeleteCluster
+      - eks:DeleteFargateProfile
+      - eks:DeleteNodegroup
       - eks:Describe*
       - eks:List*
-      - eks:CreateFargateProfile
-      - eks:DeleteFargateProfile
       - eks:TagResource
       - eks:UntagResource
-      - eks:DescribeNodegroup
       - eks:UpdateNodegroupVersion
-      - eks:DeleteNodegroup
       - elasticbeanstalk:CreateApplication
       - elasticbeanstalk:DeleteApplication
       - elasticbeanstalk:Describe*
@@ -114,16 +112,15 @@ Statement:
     Effect: Allow
     Action:
       - cloudfront:CreateDistribution
-      - cloudfront:CreateStreamingDistribution
-      - cloudfront:CreateStreamingDistributionWithTags
+      - cloudfront:CreateStreamingDistribution*
     Resource:
       - "*"
 
   - Sid: AllowUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - bedrock:ListFoundationModels
       - bedrock:GetFoundationModel
+      - bedrock:ListFoundationModels
       - cloudfront:CreateCloudFrontOriginAccessIdentity
       - cloudfront:Get*
       - cloudfront:List*
@@ -155,28 +152,27 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - ecs:DeregisterTaskDefinition
       - ecs:Describe*
       - ecs:List*
-      - ecs:TagResource
-      - ecs:UntagResource
       - ecs:PutAccountSetting
       - ecs:RegisterTaskDefinition
-      - ecs:DeregisterTaskDefinition
+      - ecs:TagResource
+      - ecs:UntagResource
     Resource:
       - "*"
 
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurFees
     Effect: Allow
     Action:
+      - ecs:*CapacityProvider*
+      - ecs:CreateService
+      - ecs:DeleteCluster
+      - ecs:DeleteService
       - ecs:RunTask
       - ecs:StartTask
       - ecs:StopTask
-      - ecs:DeleteCluster
-      - ecs:CreateService
-      - ecs:DeleteService
-      - ecs:UpdateService
       - ecs:UpdateCluster
-      - ecs:*CapacityProvider
-      - ecs:PutClusterCapacityProviders
+      - ecs:UpdateService
     Resource:
       - 'arn:aws:ecs:{{ aws_region }}:{{ aws_account_id }}:*'

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -102,12 +102,12 @@ Statement:
       - secretsmanager:CreateSecret
       - secretsmanager:Delete*
       - secretsmanager:Get*
+      - secretsmanager:PutResourcePolicy
+      - secretsmanager:RemoveRegionsFromReplication
       - secretsmanager:RotateSecret
       - secretsmanager:TagResource
       - secretsmanager:UntagResource
       - secretsmanager:UpdateSecret
-      - secretsmanager:PutResourcePolicy
-      - secretsmanager:RemoveRegionsFromReplication
     Resource:
       - 'arn:aws:iam::{{ aws_account_id }}:server-certificate/ansible-test-*'
       - 'arn:aws:secretsmanager:{{ aws_region }}:{{ aws_account_id }}:secret:ansible-test*'
@@ -123,11 +123,11 @@ Statement:
       - acm:RemoveTagsFromCertificate
       - acm:RenewCertificate
       - acm:RequestCertificate
+      - iam:*InstanceProfile
       - iam:CreateRole
       - iam:CreateSAMLProvider
       - iam:DeleteRole
       - iam:DeleteSAMLProvider
-      - iam:*InstanceProfile
       - iam:GetSAMLProvider
       - iam:GetServerCertificate
       - iam:PassRole

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -66,6 +66,11 @@ Statement:
       - backup:UntagResource
       - backup:UpdateBackupPlan
       - backup-storage:MountCapsule
+      - ecr:CreateRepository
+      - ecr:Describe*
+      - ecr:GetAuthorizationToken
+      - ecr:List*
+      - ecr:PutImageTagMutability
       - memorydb:Describe*
       - memorydb:List*
     Resource: "*"
@@ -103,3 +108,29 @@ Statement:
       - memorydb:TagResource
     Resource:
       - 'arn:aws:memorydb:{{ aws_region }}:{{ aws_account_id }}:*'
+
+  - Sid: AllowResourceRestrictedActionsWhichIncurFees
+    Effect: Allow
+    Action:
+      - ecr:CompleteLayerUpload
+      - ecr:InitiateLayerUpload
+      - ecr:PutImage
+      - ecr:UploadLayerPart
+    Resource:
+      - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'
+
+  - Sid: AllowResourceRestrictedActionsWhichIncurNoFees
+    Effect: Allow
+    Action:
+      - ecr:BatchCheckLayerAvailability
+      - ecr:BatchDeleteImages
+      - ecr:DeleteLifecyclePolicy
+      - ecr:DeleteRepository
+      - ecr:DeleteRepositoryPolicy
+      - ecr:GetLifecyclePolicy
+      - ecr:GetRepositoryPolicy
+      - ecr:PutImageScanningConfiguration
+      - ecr:PutLifecyclePolicy
+      - ecr:SetRepositoryPolicy
+    Resource:
+      - 'arn:aws:ecr:{{ aws_region }}:{{ aws_account_id }}:repository/*'

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -95,14 +95,14 @@ Statement:
   - Sid: AllowRegionalRestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - memorydb:CreateACL
       - memorydb:CreateParameterGroup
       - memorydb:CreateSubnetGroup
       - memorydb:CreateUser
-      - memorydb:CreateACL
       - memorydb:DeleteACL
       - memorydb:DeleteCluster
       - memorydb:DeleteParameterGroup
-      - memorydb:DeleleSnapshot
+      - memorydb:DeleteSnapshot
       - memorydb:DeleteSubnetGroup
       - memorydb:DeleteUser
       - memorydb:TagResource

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -68,7 +68,7 @@ Statement:
       - backup-storage:MountCapsule
       - ecr:CreateRepository
       - ecr:Describe*
-      - ecr:GetAuthorizationToken
+      - ecr:Get*
       - ecr:List*
       - ecr:PutImageTagMutability
       - memorydb:Describe*
@@ -127,8 +127,6 @@ Statement:
       - ecr:DeleteLifecyclePolicy
       - ecr:DeleteRepository
       - ecr:DeleteRepositoryPolicy
-      - ecr:GetLifecyclePolicy
-      - ecr:GetRepositoryPolicy
       - ecr:PutImageScanningConfiguration
       - ecr:PutLifecyclePolicy
       - ecr:SetRepositoryPolicy


### PR DESCRIPTION
## Summary

  - **Redistribute ECR** from `paas.yaml` to `storage-services.yaml` — natural fit alongside S3, EFS, Backup, and MemoryDB, and frees up space in `paas.yaml` for future
  SageMaker/Bedrock growth
  - **Fix typo**: `memorydb:DeleleSnapshot` → `memorydb:DeleteSnapshot` (silent permission bug — delete-snapshot was never actually granted)
  - **Remove duplicates**: `glue:Get*` was in both `application-services.yaml` and `data-services.yaml`; duplicate `arn:aws:dms:...endpoint:*` resource ARN in
  `data-services.yaml`
  - **Sort alphabetically**: all action lists and resource ARNs across all 8 policy files, making it easier to spot duplicates and review diffs
  - **Wildcard read-only actions**: `lightsail:Get*`, `bedrock:Invoke*`, `cloudfront:CreateStreamingDistribution*`, `ecs:*CapacityProvider*`
  - **Remove redundancy**: `eks:DescribeNodegroup` was already covered by `eks:Describe*`

  ## Policy size impact (JSON chars, limit: 6,144)

  | Policy file | Before | After | Change | Headroom |
  |---|---|---|---|---|
  | paas.yaml | 6,021 | 5,117 | -904 (-15.0%) | 1,027 |
  | storage-services.yaml | 2,749 | 3,548 | +799 (+29.1%) | 2,596 |
  | application-services.yaml | 4,818 | 4,805 | -13 (-0.3%) | 1,339 |
  | data-services.yaml | 5,433 | 5,384 | -49 (-0.9%) | 760 |
  | application-security.yaml | 2,182 | 2,182 | 0 | 3,962 |
  | compute.yaml | 5,791 | 5,791 | 0 | 353 |
  | networking.yaml | 5,420 | 5,420 | 0 | 724 |
  | security-services.yaml | 6,082 | 6,082 | 0 | 62 |

  Sizes calculated using the same method as `deploy-test-policy.yml`: `lookup('template', ...) | from_yaml | to_json | length`.

  ## Motivation

  PR #342 proposes adding 2 new policy files (`paas-sagemaker.yaml`, `security-services-slr.yaml`), which would bring the total to 10 — the AWS default limit for managed policies per role. This redistribution avoids that by freeing up ~900 chars in `paas.yaml` through moving ECR to `storage-services.yaml`, keeping the policy count at 8 and leaving room for future growth.

  ## Test plan
  
  - [ ] Verify all policies stay under 6,144 chars: `make test_policy STAGE=dev`
  - [ ] Verify no functional permission changes beyond the fixes noted above
  - [ ] Confirm ECR operations still work (permissions moved, not removed)
  - [ ] Confirm MemoryDB snapshot deletion works (typo fix grants the permission for the first time)