### PR TITLE
Policy sort linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: policy-sort
+        name: Check policy action sort order
+        entry: python hacking/check_policy_sort.py
+        language: python
+        additional_dependencies: [PyYAML]
+        files: ^aws/policy/.*\.yaml$
+        pass_filenames: false

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -13,7 +13,6 @@ Statement:
       - cloudformation:Get*
       - cloudformation:List*
       - cloudformation:UpdateResource
-      ###
       - cloudwatch:Describe*
       - codebuild:BatchGetProjects
       - codebuild:List*
@@ -56,6 +55,8 @@ Statement:
       - ses:VerifyDomainDkim
       - ses:VerifyDomainIdentity
       - ses:VerifyEmailIdentity
+      - SNS:Get*
+      - SNS:List*
       - sqs:CreateQueue
       - sqs:DeleteQueue
       - sqs:Get*
@@ -80,8 +81,6 @@ Statement:
       - ssmmessages:CreateDataChannel
       - ssmmessages:OpenControlChannel
       - ssmmessages:OpenDataChannel
-      - SNS:Get*
-      - SNS:List*
       - states:Describe*
       - states:List*
     Resource: "*"

--- a/aws/policy/compute.yaml
+++ b/aws/policy/compute.yaml
@@ -146,8 +146,8 @@ Statement:
       - autoscaling:CompleteLifecycleAction
       - autoscaling:CreateOrUpdateTags
       - autoscaling:Delete*
-      - autoscaling:DetachLoadBalancerTargetGroups
       - autoscaling:DetachLoadBalancers
+      - autoscaling:DetachLoadBalancerTargetGroups
       - autoscaling:DisableMetricsCollection
       - autoscaling:PutLifecycleHook
       - autoscaling:PutScalingPolicy

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -9,8 +9,8 @@ Statement:
       - eks:CreateNodegroup
       - eks:UpdateNodegroupConfig
       - lambda:InvokeFunction
-      - lightsail:CreateInstanceSnapshot
       - lightsail:CreateInstances
+      - lightsail:CreateInstanceSnapshot
       - lightsail:StartInstance
     Resource:
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
@@ -132,8 +132,8 @@ Statement:
     Effect: Allow
     Action:
       - lambda:CreateEventSourceMapping
-      - lambda:UpdateEventSourceMapping
       - lambda:DeleteEventSourceMapping
+      - lambda:UpdateEventSourceMapping
     Resource:
       - "*"
     Condition:

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -41,8 +41,8 @@ Statement:
   - Sid: RegionalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - iam:GetUser
       - acm:List*
+      - iam:GetUser
     Resource: "*"
     Condition:
       StringEquals:

--- a/aws/policy/storage-services.yaml
+++ b/aws/policy/storage-services.yaml
@@ -3,6 +3,37 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - backup-storage:MountCapsule
+      - backup:CreateBackupPlan
+      - backup:CreateBackupSelection
+      - backup:CreateBackupVault
+      - backup:DeleteBackupPlan
+      - backup:DeleteBackupSelection
+      - backup:DeleteBackupVault
+      - backup:Describe*
+      - backup:GetBackup*
+      - backup:List*
+      - backup:TagResource
+      - backup:UntagResource
+      - backup:UpdateBackupPlan
+      - ecr:CreateRepository
+      - ecr:Describe*
+      - ecr:Get*
+      - ecr:List*
+      - ecr:PutImageTagMutability
+      - elasticfilesystem:CreateFileSystem
+      - elasticfilesystem:CreateMountTarget
+      - elasticfilesystem:CreateTags
+      - elasticfilesystem:DeleteFileSystem
+      - elasticfilesystem:DeleteMountTarget
+      - elasticfilesystem:Describe*
+      - elasticfilesystem:List*
+      - elasticfilesystem:PutLifecycleConfiguration
+      - elasticfilesystem:TagResource
+      - elasticfilesystem:UntagResource
+      - elasticfilesystem:UpdateFileSystem
+      - memorydb:Describe*
+      - memorydb:List*
       - s3:CreateAccessPoint*
       - s3:CreateBucket
       - s3:DeleteAccessPoint*
@@ -26,7 +57,6 @@ Statement:
       - s3:PutBucketCors
       - s3:PutBucketLogging
       - s3:PutBucketNotification
-      - s3:PutBucketWebsite
       - s3:PutBucketObjectLockConfiguration
       - s3:PutBucketOwnershipControls
       - s3:PutBucketPolicy
@@ -34,6 +64,7 @@ Statement:
       - s3:PutBucketRequestPayment
       - s3:PutBucketTagging
       - s3:PutBucketVersioning
+      - s3:PutBucketWebsite
       - s3:PutEncryptionConfiguration
       - s3:PutInventoryConfiguration
       - s3:PutLifecycleConfiguration
@@ -42,37 +73,6 @@ Statement:
       - s3:PutObjectTagging
       - s3:PutObjectVersionTagging
       - s3:PutReplicationConfiguration
-      - elasticfilesystem:CreateFileSystem
-      - elasticfilesystem:CreateMountTarget
-      - elasticfilesystem:CreateTags
-      - elasticfilesystem:DeleteFileSystem
-      - elasticfilesystem:DeleteMountTarget
-      - elasticfilesystem:Describe*
-      - elasticfilesystem:List*
-      - elasticfilesystem:PutLifecycleConfiguration
-      - elasticfilesystem:TagResource
-      - elasticfilesystem:UntagResource
-      - elasticfilesystem:UpdateFileSystem
-      - backup:CreateBackupPlan
-      - backup:CreateBackupSelection
-      - backup:CreateBackupVault
-      - backup:DeleteBackupPlan
-      - backup:DeleteBackupSelection
-      - backup:DeleteBackupVault
-      - backup:Describe*
-      - backup:GetBackup*
-      - backup:List*
-      - backup:TagResource
-      - backup:UntagResource
-      - backup:UpdateBackupPlan
-      - backup-storage:MountCapsule
-      - ecr:CreateRepository
-      - ecr:Describe*
-      - ecr:Get*
-      - ecr:List*
-      - ecr:PutImageTagMutability
-      - memorydb:Describe*
-      - memorydb:List*
     Resource: "*"
 
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurFees

--- a/hacking/check_policy_sort.py
+++ b/hacking/check_policy_sort.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""Check that Action lists in IAM policy YAML files are sorted alphabetically (case-insensitive)."""
+import glob
+import sys
+from typing import Any
+
+import yaml
+
+
+def check_file(path: str) -> list[str]:
+    """Validate that every Action list in a policy file is sorted case-insensitively."""
+    errors: list[str] = []
+    with open(path) as f:
+        policy: dict[str, Any] = yaml.safe_load(f)
+
+    for statement in policy.get('Statement', []):
+        sid: str = statement.get('Sid', '<no Sid>')
+        actions: list[str] | str = statement.get('Action', [])
+        if isinstance(actions, str):
+            continue
+        sorted_actions: list[str] = sorted(actions, key=str.casefold)
+        if actions != sorted_actions:
+            out_of_order: list[str] = []
+            for actual, expected in zip(actions, sorted_actions):
+                if actual != expected:
+                    out_of_order.append(f'    {actual}')
+            errors.append(
+                f'{path}: statement "{sid}" has unsorted actions:\n'
+                + '\n'.join(out_of_order)
+            )
+    return errors
+
+
+def main() -> int:
+    """Check all policy files and report any unsorted action lists."""
+    paths: list[str] = glob.glob('aws/policy/*.yaml')
+    if not paths:
+        print('No policy files found', file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    for path in sorted(paths):
+        all_errors.extend(check_file(path))
+
+    if all_errors:
+        print('Policy action sort errors:\n', file=sys.stderr)
+        for error in all_errors:
+            print(error, file=sys.stderr)
+        print(f'\nFound {len(all_errors)} unsorted action list(s).', file=sys.stderr)
+        return 1
+
+    print(f'All action lists in {len(paths)} policy files are sorted.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=pycodestyle,pylint,yamllint,policy-size,policy
+envlist=pycodestyle,pylint,yamllint,policy-size,policy-sort,policy
 
 [test-deps]
 deps =
@@ -37,6 +37,12 @@ description = Report rendered size of each IAM policy file
 deps =
   PyYAML
 commands = python {toxinidir}/hacking/check_policy_size.py
+
+[testenv:policy-sort]
+description = Check that policy action lists are sorted alphabetically
+deps =
+  pre-commit
+commands = pre-commit run policy-sort --all-files
 
 [testenv:policy]
 description = Run the test-policies playbook


### PR DESCRIPTION
## Summary

- Add a pre-commit hook and tox environment (policy-sort) that checks all IAM policy YAML files have their Action lists sorted alphabetically (case-insensitive)
- Sort all existing action lists across all 8 policy files
- Linter script lives at hacking/check_policy_sort.py, runnable standalone or via tox -e policy-sort

Follows up on the suggestion in #343 to add a linter enforcing sort order.

## Test plan

- [ ] Run tox -e policy-sort and confirm it passes
- [ ] Run pre-commit run policy-sort --all-files and confirm it passes
- [ ] Intentionally unsort an action list and verify the linter catches it