### PR TITLE
Move CloudWatch Logs permissions from security-services to application-services.yml

### DIFF
--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -35,6 +35,8 @@ Statement:
       - events:RemoveTargets
       - kinesis:Describe*
       - kinesis:List*
+      # logs permissions moved back from security-services.yaml to free up space there
+      - logs:List*
       - mq:Describe*
       - mq:List*
       - ses:CreateReceiptRuleSet
@@ -114,6 +116,16 @@ Statement:
       - kinesis:RemoveTagsFromStream
       - kinesis:StartStreamEncryption
       - kinesis:StopStreamEncryption
+      - logs:AssociateKmsKey
+      - logs:CreateLogGroup
+      - logs:DeleteLogGroup
+      - logs:DeleteMetricFilter
+      - logs:Describe*
+      - logs:DisassociateKmsKey
+      - logs:PutMetricFilter
+      - logs:PutRetentionPolicy
+      - logs:Tag*
+      - logs:Untag*
       - mq:CreateTags
       - SNS:CreateTopic
       - SNS:DeleteTopic
@@ -139,6 +151,8 @@ Statement:
       - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:crawler/*'
       - 'arn:aws:glue:{{ aws_region }}:{{ aws_account_id }}:job/*'
       - 'arn:aws:kinesis:{{ aws_region }}:{{ aws_account_id }}:stream/*'
+      - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:*'
+      - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:ansible-test*'
       - 'arn:aws:mq:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:sns:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:ssm:{{ aws_region }}:{{ aws_account_id }}:document/*'

--- a/aws/policy/application-services.yaml
+++ b/aws/policy/application-services.yaml
@@ -35,7 +35,8 @@ Statement:
       - events:RemoveTargets
       - kinesis:Describe*
       - kinesis:List*
-      # logs permissions moved back from security-services.yaml to free up space there
+      # logs permissions were moved to security-services.yaml in a0ab01a to free
+      # space here, and moved back to free space there (see PR #343 discussion).
       - logs:List*
       - mq:Describe*
       - mq:List*
@@ -116,6 +117,8 @@ Statement:
       - kinesis:RemoveTagsFromStream
       - kinesis:StartStreamEncryption
       - kinesis:StopStreamEncryption
+      # logs permissions were moved to security-services.yaml in a0ab01a to free
+      # space here, and moved back to free space there (see PR #343 discussion).
       - logs:AssociateKmsKey
       - logs:CreateLogGroup
       - logs:DeleteLogGroup

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -88,7 +88,6 @@ Statement:
       - kms:UpdateGrant
       - kms:UpdateKeyDescription
       - kms:Verify
-      - logs:List*
       - secretsmanager:Describe*
       - secretsmanager:GetRandomPassword
       - secretsmanager:List*
@@ -134,16 +133,6 @@ Statement:
       - iam:UpdateSAMLProvider
       - iam:UpdateServerCertificate
       - kms:Decrypt
-      - logs:AssociateKmsKey
-      - logs:CreateLogGroup
-      - logs:DeleteLogGroup
-      - logs:DeleteMetricFilter
-      - logs:Describe*
-      - logs:DisassociateKmsKey
-      - logs:PutMetricFilter
-      - logs:PutRetentionPolicy
-      - logs:Tag*
-      - logs:Untag*
       - sts:AssumeRole
     Resource:
       - 'arn:aws:acm:{{ aws_region }}:{{ aws_account_id }}:certificate/*'
@@ -155,8 +144,6 @@ Statement:
       - 'arn:aws:iam::{{ aws_account_id }}:role/dms-vpc-role'
       - 'arn:aws:iam::{{ aws_account_id }}:role/rds_export_task'
       - 'arn:aws:kms:{{ aws_region }}:{{ aws_account_id }}:key/ansible-test-*'
-      - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:*'
-      - 'arn:aws:logs:{{ aws_region }}:{{ aws_account_id }}:log-group:ansible-test*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS'
 
   # This allows AWS Services to automatically create their Default Service Linked Roles


### PR DESCRIPTION
## Summary

- Move CloudWatch Logs permissions back from security-services.yaml to application-services.yaml, reversing the space-driven move from a0ab01a (https://github.com/mattclay/aws-terminator/commit/a0ab01a). This frees ~350 bytes in security-services.yaml (62 → 411 bytes remaining), unblocking additions like PR #342 (SageMaker Image support).

## Context

security-services.yaml was at 6,082/6,144 bytes (62 bytes remaining), making it impossible to add new permissions without hitting the AWS managed policy size limit. The CloudWatch Logs permissions were originally in application-services.yaml alongside cloudwatch and were only moved to security-services.yaml in 2022 to free space there at the time.

## Changes

aws/policy/security-services.yaml — removed:
- logs:List* from GlobalUnrestrictedResourceActionsWhichIncurNoFees
- logs:AssociateKmsKey, logs:CreateLogGroup, logs:DeleteLogGroup, logs:DeleteMetricFilter, logs:Describe*, logs:DisassociateKmsKey, logs:PutMetricFilter, logs:PutRetentionPolicy, logs:Tag*, logs:Untag* from ResourceRestrictedActionsWhichIncurNoFees
- Two log-group resource ARNs from the same statement

aws/policy/application-services.yaml — added the same actions and resource ARNs to matching statements with identical Resource/Condition structure.

All policy files are attached to the same IAM principal, so moving permissions between files has no effect on effective permissions.


## Test plan

- [ ] Run tox -e policy to verify policies are within size limits
- [ ] Verify no change in effective IAM permissions when all policies principal