### PR TITLE
Add policy size report tool and tox environment

### DIFF
--- a/hacking/check_policy_size.py
+++ b/hacking/check_policy_size.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Report rendered JSON size of each IAM policy file against the AWS 6144-byte limit."""
+import glob
+import json
+import sys
+from typing import Any
+
+import yaml
+
+AWS_LIMIT = 6144
+THRESHOLD = 6124  # 20-byte buffer, matches test-policies.yml
+
+
+def render_policy(path: str, region: str = 'us-east-1', account_id: str = '123456789012') -> str:
+    """Render a policy YAML template to JSON, substituting placeholder variables."""
+    with open(path) as f:
+        content = f.read()
+    content = content.replace('{{ aws_region }}', region)
+    content = content.replace('{{ aws_account_id }}', account_id)
+    policy: dict[str, Any] = yaml.safe_load(content)
+    return json.dumps(policy)
+
+
+def main() -> int:
+    """Check all policy files and report their rendered sizes."""
+    paths = glob.glob('aws/policy/*.yaml')
+    if not paths:
+        print('No policy files found', file=sys.stderr)
+        return 1
+
+    has_error = False
+    for path in sorted(paths):
+        rendered = render_policy(path)
+        size = len(rendered)
+        remaining = AWS_LIMIT - size
+        pct = size / AWS_LIMIT * 100
+
+        if size > THRESHOLD:
+            status = 'OVER' if size > AWS_LIMIT else 'TIGHT'
+            has_error = size > AWS_LIMIT
+        elif remaining < 500:
+            status = 'WARN'
+        else:
+            status = 'OK'
+
+        bar_len = 40
+        filled = int(bar_len * size / AWS_LIMIT)
+        bar = '#' * filled + '-' * (bar_len - filled)
+
+        print(f'  {status:5s} [{bar}] {size:5d}/{AWS_LIMIT} ({remaining:+5d} remaining)  {path}')
+
+    print()
+    print(f'  Limit: {AWS_LIMIT} bytes | Threshold: {THRESHOLD} bytes')
+    return 1 if has_error else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hacking/check_policy_size.py
+++ b/hacking/check_policy_size.py
@@ -33,7 +33,7 @@ def main() -> int:
         rendered = render_policy(path)
         size = len(rendered)
         remaining = AWS_LIMIT - size
-        pct = size / AWS_LIMIT * 100
+        
 
         if size > THRESHOLD:
             status = 'OVER' if size > AWS_LIMIT else 'TIGHT'

--- a/hacking/check_policy_size.py
+++ b/hacking/check_policy_size.py
@@ -37,7 +37,7 @@ def main() -> int:
 
         if size > THRESHOLD:
             status = 'OVER' if size > AWS_LIMIT else 'TIGHT'
-            has_error = size > AWS_LIMIT
+            has_error |= size > AWS_LIMIT
         elif remaining < 500:
             status = 'WARN'
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=pycodestyle,pylint,yamllint,policy
+envlist=pycodestyle,pylint,yamllint,policy-size,policy
 
 [test-deps]
 deps =
@@ -31,6 +31,12 @@ deps =
   {[test-deps]deps}
   yamllint
 commands = yamllint --config-file {toxinidir}/.yamllint {toxinidir}
+
+[testenv:policy-size]
+description = Report rendered size of each IAM policy file
+deps =
+  PyYAML
+commands = python {toxinidir}/hacking/check_policy_size.py
 
 [testenv:policy]
 description = Run the test-policies playbook


### PR DESCRIPTION
## Summary

- Add `hacking/check_policy_size.py` — reports the rendered JSON size of each IAM policy file against the AWS 6,144-byte managed policy limit
- Add `policy-size` tox environment so the check runs in CI and locally via `tox -e policy-size`
- Outputs a visual bar chart showing each policy's usage, with status labels: OK, WARN (< 500 bytes remaining), TIGHT (< 20 bytes remaining), OVER (exceeds limit)

## Example output

```
  OK    [##############--------------------------]  2182/6144 (+3962 remaining)  aws/policy/application-security.yaml
  OK    [###############################---------]  4805/6144 (+1339 remaining)  aws/policy/application-services.yaml
  WARN  [#####################################---]  5791/6144 ( +353 remaining)  aws/policy/compute.yaml
  OK    [###################################-----]  5384/6144 ( +760 remaining)  aws/policy/data-services.yaml
  OK    [###################################-----]  5420/6144 ( +724 remaining)  aws/policy/networking.yaml
  OK    [################################--------]  5045/6144 (+1099 remaining)  aws/policy/paas.yaml
  WARN  [#######################################-]  6082/6144 (  +62 remaining)  aws/policy/security-services.yaml
  OK    [######################------------------]  3478/6144 (+2666 remaining)  aws/policy/storage-services.yaml
```
## Motivation

Policy files are Ansible YAML templates rendered to JSON at deploy tim44-byte limit on managed policies. Without a size check, it's easy toadd permissions that push a policy over the limit, which only surfaces at deploy time. This gives early visibility in CI and local development.

## Test plan

- [ ] `tox -e policy-size` runs and shows the size report
- [ ] Adding a policy that exceeds 6,144 bytes causes the check to exit with code 1