### PR TITLE
Add permissions and terminator for AgentCoreRuntime

### DIFF
--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -23,9 +23,11 @@ Statement:
   - Sid: AllowResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - bedrock-agentcore:CreateAgent*
-      - bedrock-agentcore:DeleteAgent*
-      - bedrock-agentcore:UpdateAgent*
+      - bedrock-agentcore:*AgentRuntime*
+      - bedrock-agentcore:*AgentRuntimeEndpoint
+      - bedrock-agentcore:*TagResource*
+      - bedrock-agentcore:*WorkloadIdentity
+      - bedrock:CreateAgent*
       - bedrock:CreateAgent*
       - bedrock:DeleteAgent*
       - bedrock:DisableAgentActionGroup
@@ -101,6 +103,7 @@ Statement:
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent/*'
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
       - 'arn:aws:bedrock-agentcore:{{ aws_region }}:{{ aws_account_id }}:runtime/*'
+      - 'arn:aws:bedrock-agentcore:{{ aws_region }}:{{ aws_account_id }}:workload-identity-directory/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:cache-policy/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:distribution/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:origin-access-identity/*'

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -70,7 +70,7 @@ Statement:
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
-      - bedrock-agentcore:*AgentRuntime*
+      - bedrock-agentcore:*AgentRuntime
       - bedrock-agentcore:*AgentRuntimeEndpoint
       - bedrock-agentcore:*TagResource*
       - bedrock-agentcore:*WorkloadIdentity

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -72,10 +72,13 @@ Statement:
   - Sid: AllowGlobalRestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      # Matches Create/Delete/UpdateAgentRuntime
       - bedrock-agentcore:*AgentRuntime
+      # Matches Create/Delete/UpdateAgentRuntimeEndpoint
       - bedrock-agentcore:*AgentRuntimeEndpoint
       # Matches TagResource and UntagResource (IAM action matching is case-insensitive)
       - bedrock-agentcore:*TagResource
+      # Matches Create/Delete/UpdateWorkloadIdentity
       - bedrock-agentcore:*WorkloadIdentity
       - bedrock:CreateAgent*
       - bedrock:DeleteAgent*

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -75,7 +75,6 @@ Statement:
       - bedrock-agentcore:*TagResource*
       - bedrock-agentcore:*WorkloadIdentity
       - bedrock:CreateAgent*
-      - bedrock:CreateAgent*
       - bedrock:DeleteAgent*
       - bedrock:DisableAgentActionGroup
       - bedrock:PrepareAgent
@@ -148,9 +147,9 @@ Statement:
       # covered by sagemaker:List* in unrestricted (IAM action matching is case-insensitive)
       - sagemaker:*Tags
     Resource:
-      - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
       - 'arn:aws:bedrock-agentcore:{{ aws_region }}:{{ aws_account_id }}:runtime/*'
       - 'arn:aws:bedrock-agentcore:{{ aws_region }}:{{ aws_account_id }}:workload-identity-directory/*'
+      - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent/*'
       # CloudFront is a global service (no region in ARNs)
       - 'arn:aws:cloudfront::{{ aws_account_id }}:cache-policy/*'
@@ -167,31 +166,6 @@ Statement:
       - 'arn:aws:lightsail:{{ aws_region }}:{{ aws_account_id }}:*'
       - 'arn:aws:sagemaker:{{ aws_region }}:{{ aws_account_id }}:code-repository/*'
       - 'arn:aws:sagemaker:{{ aws_region }}:{{ aws_account_id }}:image/*'
-
-  - Sid: AllowUnrestrictedResourceActionsWhichIncurFees
-    Effect: Allow
-    Action:
-      - cloudfront:CreateDistribution
-      - cloudfront:CreateStreamingDistribution*
-    Resource:
-      - "*"
-
-  - Sid: AllowUnrestrictedResourceActionsWhichIncurNoFees
-    Effect: Allow
-    Action:
-      - bedrock-agentcore:Get*
-      - bedrock-agentcore:List*
-      - bedrock:Get*
-      - bedrock:List*
-      - cloudfront:CreateCloudFrontOriginAccessIdentity
-      - cloudfront:Get*
-      - cloudfront:List*
-      - lambda:GetEventSourceMapping
-      - lambda:List*
-      - sagemaker:Describe*
-      - sagemaker:List*
-    Resource:
-      - "*"
       - 'arn:aws:sagemaker:{{ aws_region }}:{{ aws_account_id }}:model/*'
 
   - Sid: AllowLambdaEventSourceMappings

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -23,14 +23,14 @@ Statement:
   - Sid: AllowResourceRestrictedActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - bedrock-agentcore:CreateAgent*
+      - bedrock-agentcore:DeleteAgent*
+      - bedrock-agentcore:UpdateAgent*
       - bedrock:CreateAgent*
       - bedrock:DeleteAgent*
       - bedrock:DisableAgentActionGroup
       - bedrock:PrepareAgent
       - bedrock:UpdateAgent*
-      - bedrock-agentcore:CreateAgent*
-      - bedrock-agentcore:DeleteAgent*
-      - bedrock-agentcore:UpdateAgent*
       - cloudfront:CreateCachePolicy
       - cloudfront:CreateInvalidation
       - cloudfront:CreateOriginRequestPolicy
@@ -127,10 +127,10 @@ Statement:
   - Sid: AllowUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - bedrock-agentcore:Get*
+      - bedrock-agentcore:List*
       - bedrock:Get*
       - bedrock:List*
-      - bedrock-agentcore:List*
-      - bedrock-agentcore:Get*
       - cloudfront:CreateCloudFrontOriginAccessIdentity
       - cloudfront:Get*
       - cloudfront:List*

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -74,7 +74,8 @@ Statement:
     Action:
       - bedrock-agentcore:*AgentRuntime
       - bedrock-agentcore:*AgentRuntimeEndpoint
-      - bedrock-agentcore:*TagResource*
+      # Matches TagResource and UntagResource (IAM action matching is case-insensitive)
+      - bedrock-agentcore:*TagResource
       - bedrock-agentcore:*WorkloadIdentity
       - bedrock:CreateAgent*
       - bedrock:DeleteAgent*

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -17,6 +17,8 @@ Statement:
   - Sid: AllowGlobalUnrestrictedResourceActionsWhichIncurNoFees
     Effect: Allow
     Action:
+      - bedrock-agentcore:Get*
+      - bedrock-agentcore:List*
       - bedrock:Get*
       - bedrock:List*
       - cloudfront:CreateCloudFrontOriginAccessIdentity

--- a/aws/policy/paas.yaml
+++ b/aws/policy/paas.yaml
@@ -28,6 +28,9 @@ Statement:
       - bedrock:DisableAgentActionGroup
       - bedrock:PrepareAgent
       - bedrock:UpdateAgent*
+      - bedrock-agentcore:CreateAgent*
+      - bedrock-agentcore:DeleteAgent*
+      - bedrock-agentcore:UpdateAgent*
       - cloudfront:CreateCachePolicy
       - cloudfront:CreateInvalidation
       - cloudfront:CreateOriginRequestPolicy
@@ -97,6 +100,7 @@ Statement:
     Resource:
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent/*'
       - 'arn:aws:bedrock:{{ aws_region }}:{{ aws_account_id }}:agent-alias/*'
+      - 'arn:aws:bedrock-agentcore:{{ aws_region }}:{{ aws_account_id }}:runtime/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:cache-policy/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:distribution/*'
       - 'arn:aws:cloudfront::{{ aws_account_id }}:origin-access-identity/*'
@@ -125,6 +129,8 @@ Statement:
     Action:
       - bedrock:Get*
       - bedrock:List*
+      - bedrock-agentcore:List*
+      - bedrock-agentcore:Get*
       - cloudfront:CreateCloudFrontOriginAccessIdentity
       - cloudfront:Get*
       - cloudfront:List*

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -157,6 +157,8 @@ Statement:
     Resource:
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/autoscaling.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/bedrock.amazonaws.com/*'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/bedrock-agentcore.amazonaws.com/*'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/runtime-identity.bedrock-agentcore.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/spot.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/eks-fargate.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/eks-nodegroup.amazonaws.com/*'
@@ -169,6 +171,8 @@ Statement:
         iam:AWSServiceName:
           - 'autoscaling.amazonaws.com'
           - 'bedrock.amazonaws.com'
+          - 'bedrock-agentcore.amazonaws.com'
+          - 'runtime-identity.bedrock-agentcore.amazonaws.com'
           - 'spot.amazonaws.com'
           - 'eks-fargate.amazonaws.com'
           - 'eks-nodegroup.amazonaws.com'

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -14,6 +14,7 @@ Statement:
       ArnLike:
         iam:PolicyArn:
           - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
+          - 'arn:aws:iam::aws:policy/BedrockAgentCoreFullAccess'
           - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'
           - 'arn:aws:iam::aws:policy/AWSDenyAll'
           - 'arn:aws:iam::aws:policy/AmazonEKSServicePolicy'

--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -15,7 +15,6 @@ Statement:
         iam:PolicyArn:
           - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
           - 'arn:aws:iam::aws:policy/BedrockAgentCoreFullAccess'
-          - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'
           - 'arn:aws:iam::aws:policy/AWSDenyAll'
           - 'arn:aws:iam::aws:policy/AmazonEKSServicePolicy'
           - 'arn:aws:iam::aws:policy/AmazonEKSClusterPolicy'
@@ -149,15 +148,14 @@ Statement:
       - iam:CreateServiceLinkedRole
     Resource:
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/autoscaling.amazonaws.com/*'
-      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/bedrock.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/bedrock-agentcore.amazonaws.com/*'
-      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/runtime-identity.bedrock-agentcore.amazonaws.com/*'
-      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/spot.amazonaws.com/*'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/bedrock.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/ecs.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/eks-fargate.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/eks-nodegroup.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/memorydb.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/network-firewall.amazonaws.com/*'
+      - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/runtime-identity.bedrock-agentcore.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/spot.amazonaws.com/*'
       - 'arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/transitgateway.amazonaws.com/*'
     Condition:

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -426,7 +426,7 @@ class BedrockAgentCoreRuntime(Terminator):
     @property
     def created_time(self):
         return self.instance.get("lastUpdatedAt")
-    
+
     @property
     def id(self):
         return self.instance.get('agentRuntimeId')

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -440,6 +440,20 @@ class BedrockAgentCoreRuntime(Terminator):
         return self.instance.get("status") in ("CREATING", "UPDATING", "DELETING")
 
     def terminate(self):
+        def _paginate_runtime_endpoints():
+            runtime_endpoints = self.client.get_paginator('list_agent_runtime_endpoints').paginate(
+                agentRuntimeId=self.id).build_full_result()['runtimeEndpoints']
+
+            return [] if not runtime_endpoints else runtime_endpoints
+
+        # Delete all runtime endpoints associated with this agent runtime first
+        runtime_endpoints = _paginate_runtime_endpoints()
+        for endpoint in runtime_endpoints:
+            self.client.delete_agent_runtime_endpoint(
+                agentRuntimeId=self.id,
+                endpointName=endpoint['name']
+            )
+
         self.client.delete_agent_runtime(agentRuntimeId=self.id)
 
 

--- a/aws/terminator/paas.py
+++ b/aws/terminator/paas.py
@@ -413,6 +413,36 @@ class BedrockAgent(Terminator):
         self.client.delete_agent(agentId=self.id)
 
 
+class BedrockAgentCoreRuntime(Terminator):
+    @staticmethod
+    def create(credentials):
+        def _paginate_list_agent_runtimes(client):
+            agentcore_runtimes = client.get_paginator('list_agent_runtimes').paginate().build_full_result()['agentRuntimes']
+
+            return [] if not agentcore_runtimes else agentcore_runtimes
+
+        return Terminator._create(credentials, BedrockAgentCoreRuntime, 'bedrock-agentcore-control', _paginate_list_agent_runtimes)
+
+    @property
+    def created_time(self):
+        return self.instance.get("lastUpdatedAt")
+    
+    @property
+    def id(self):
+        return self.instance.get('agentRuntimeId')
+
+    @property
+    def name(self):
+        return self.instance.get('agentRuntimeName')
+
+    @property
+    def ignore(self) -> bool:
+        return self.instance.get("status") in ("CREATING", "UPDATING", "DELETING")
+
+    def terminate(self):
+        self.client.delete_agent_runtime(agentRuntimeId=self.id)
+
+
 class SageMakerCodeRepository(Terminator):
     @staticmethod
     def create(credentials):


### PR DESCRIPTION
## Summary

Adds the IAM permissions and terminator needed for the `agentcore_runtime` integration tests in [ansible-collections/amazon.ai](https://github.com/ansible-collections/amazon.ai) (see PR [#59](https://github.com/ansible-collections/amazon.ai/pull/59)).
