### PR TITLE
Revert removal of AmazonSageMakerFullAccess policy

### DIFF
--- a/aws/policy/security-services.yaml
+++ b/aws/policy/security-services.yaml
@@ -14,6 +14,7 @@ Statement:
       ArnLike:
         iam:PolicyArn:
           - 'arn:aws:iam::aws:policy/AmazonBedrockFullAccess'
+          - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'
           - 'arn:aws:iam::aws:policy/BedrockAgentCoreFullAccess'
           - 'arn:aws:iam::aws:policy/AWSDenyAll'
           - 'arn:aws:iam::aws:policy/AmazonEKSServicePolicy'


### PR DESCRIPTION
Was removed in 93f8fe407f0dc1290e794eecd2db7598f591c85c but it's needed for sagemaker_model integration tests.