### PR TITLE
Fix Ec2Eip and Ec2Eni termination errors for in-use resources

### DIFF
--- a/aws/terminator/networking.py
+++ b/aws/terminator/networking.py
@@ -88,7 +88,11 @@ class Ec2Eip(DbTerminator):
         return self.instance['AllocationId']
 
     def terminate(self):
-        self.client.release_address(AllocationId=self.id)
+        try:
+            self.client.release_address(AllocationId=self.id)
+        except botocore.exceptions.ClientError as ex:
+            if ex.response['Error']['Code'] != 'InvalidIPAddress.InUse':
+                raise
 
 
 class Ec2CustomerGateway(DbTerminator):
@@ -268,6 +272,10 @@ class Ec2Eni(DbTerminator):
     @property
     def name(self):
         return get_tag_dict_from_tag_list(self.instance.get('Tags')).get('Name')
+
+    @property
+    def ignore(self):
+        return self.instance.get('Status') in ('associated', 'attaching', 'in-use', 'detaching')
 
     def terminate(self):
         self.client.delete_network_interface(NetworkInterfaceId=self.id)


### PR DESCRIPTION
Ec2Eip: Catch InvalidIPAddress.InUse when releasing EIPs still associated in non-default VPCs instead of logging an error every cycle.

Ec2Eni: Skip ENIs in associated/attaching/in-use/detaching states via ignore, allowing the parent resource to be cleaned up first.